### PR TITLE
Add BMS controls using the new protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ secrets.yaml
 __pycache__/
 *.py[cod]
 *$py.class
+
+local/

--- a/components/ant_bms/__init__.py
+++ b/components/ant_bms/__init__.py
@@ -9,6 +9,7 @@ MULTI_CONF = True
 
 CONF_ANT_BMS_ID = "ant_bms_id"
 CONF_ENABLE_FAKE_TRAFFIC = "enable_fake_traffic"
+CONF_SUPPORTS_NEW_COMMANDS = "supports_new_commands"
 
 ant_bms_ns = cg.esphome_ns.namespace("ant_bms")
 AntBms = ant_bms_ns.class_("AntBms", cg.PollingComponent, ant_modbus.AntModbusDevice)
@@ -18,6 +19,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(AntBms),
             cv.Optional(CONF_ENABLE_FAKE_TRAFFIC, default=False): cv.boolean,
+            cv.Optional(CONF_SUPPORTS_NEW_COMMANDS, default=False): cv.boolean,
             cv.Optional(CONF_PASSWORD, default=""): cv.Any(
                 cv.All(cv.string_strict, cv.Length(min=8, max=8)),
                 cv.All(cv.string_strict, cv.Length(min=0, max=0)),
@@ -35,6 +37,7 @@ def to_code(config):
     yield ant_modbus.register_ant_modbus_device(var, config)
 
     cg.add(var.set_enable_fake_traffic(config[CONF_ENABLE_FAKE_TRAFFIC]))
+    cg.add(var.set_supports_new_commands(config[CONF_SUPPORTS_NEW_COMMANDS]))
 
     if CONF_PASSWORD in config:
         cg.add(var.set_password(config[CONF_PASSWORD]))

--- a/components/ant_bms/ant_bms.h
+++ b/components/ant_bms/ant_bms.h
@@ -65,9 +65,13 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
 
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
   void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
+  void set_balancer_switch(switch_::Switch *balancer_switch) { balancer_switch_ = balancer_switch; }
+  void set_bluetooth_switch(switch_::Switch *bluetooth_switch) { bluetooth_switch_ = bluetooth_switch; }
+  void set_buzzer_switch(switch_::Switch *buzzer_switch) { buzzer_switch_ = buzzer_switch; }
 
   void set_enable_fake_traffic(bool enable_fake_traffic) { enable_fake_traffic_ = enable_fake_traffic; }
   void set_password(const std::string &password) { this->password_ = password; }
+  void set_supports_new_commands(bool supports_new_commands) { supports_new_commands_ = supports_new_commands; }
 
   void dump_config() override;
 
@@ -76,6 +80,7 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
   void update() override;
 
   void write_register(uint8_t address, uint16_t value);
+  bool supports_new_commands() { return supports_new_commands_; }
 
  protected:
   sensor::Sensor *battery_strings_sensor_;
@@ -95,6 +100,9 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
 
   switch_::Switch *charging_switch_;
   switch_::Switch *discharging_switch_;
+  switch_::Switch *balancer_switch_;
+  switch_::Switch *bluetooth_switch_;
+  switch_::Switch *buzzer_switch_;
 
   text_sensor::TextSensor *charge_mosfet_status_text_sensor_;
   text_sensor::TextSensor *discharge_mosfet_status_text_sensor_;
@@ -109,6 +117,7 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
   } temperatures_[6];
 
   bool enable_fake_traffic_;
+  bool supports_new_commands_;
   std::string password_;
 
   void on_status_data_(const std::vector<uint8_t> &data);

--- a/components/ant_bms/switch/ant_switch.cpp
+++ b/components/ant_bms/switch/ant_switch.cpp
@@ -8,7 +8,20 @@ namespace ant_bms {
 static const char *const TAG = "ant_bms.switch";
 
 void AntSwitch::dump_config() { LOG_SWITCH("", "AntBms Switch", this); }
-void AntSwitch::write_state(bool state) { this->parent_->write_register(this->holding_register_, (uint16_t) state); }
+void AntSwitch::write_state(bool state) {
+  if (this->parent_->supports_new_commands()) {
+    this->parent_->write_register(
+        (state) ? this->new_protocol_turn_on_register_ : this->new_protocol_turn_off_register_, 0x0000);
+    return;
+  }
+
+  if (this->holding_register_ == 0x00) {
+    ESP_LOGW(TAG, "This switch isn't supported by the selected protocol version.");
+    return;
+  }
+
+  this->parent_->write_register(this->holding_register_, (uint16_t) state);
+}
 
 }  // namespace ant_bms
 }  // namespace esphome

--- a/components/ant_bms/switch/ant_switch.h
+++ b/components/ant_bms/switch/ant_switch.h
@@ -12,6 +12,12 @@ class AntSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(AntBms *parent) { this->parent_ = parent; };
   void set_holding_register(uint8_t holding_register) { this->holding_register_ = holding_register; };
+  void set_new_protocol_turn_on_register(uint8_t new_protocol_turn_on_register) {
+    this->new_protocol_turn_on_register_ = new_protocol_turn_on_register;
+  };
+  void set_new_protocol_turn_off_register(uint8_t new_protocol_turn_off_register) {
+    this->new_protocol_turn_off_register_ = new_protocol_turn_off_register;
+  };
   void dump_config() override;
   void loop() override {}
   float get_setup_priority() const override { return setup_priority::DATA; }
@@ -20,6 +26,8 @@ class AntSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
   AntBms *parent_;
   uint8_t holding_register_;
+  uint8_t new_protocol_turn_on_register_;
+  uint8_t new_protocol_turn_off_register_;
 };
 
 }  // namespace ant_bms

--- a/components/ant_modbus/ant_modbus.cpp
+++ b/components/ant_modbus/ant_modbus.cpp
@@ -191,6 +191,22 @@ void AntModbus::authenticate_v2021_() {
   this->flush();
 }
 
+void AntModbus::authenticate_v2021_variable_(uint8_t data_len, const uint8_t *data) {
+  std::vector<uint8_t> data = {0x7E, 0xA1, 0x23, 0x6A, 0x01};
+  data.push_back(data_len);
+  for (int i = 0; i < data_len; i++) {
+    data.push_back(data[i]);
+  }
+  auto crc = crc16(data.data() + 1, data.size());
+  data.push_back(crc >> 0);
+  data.push_back(crc >> 8);
+  data.push_back(0xAA);
+  data.push_back(0x55);
+
+  this->write_array(data);
+  this->flush();
+}
+
 void AntModbus::send_v2021(uint8_t function, uint8_t address, uint16_t value) {
   this->authenticate_v2021_();
 

--- a/components/ant_modbus/ant_modbus.cpp
+++ b/components/ant_modbus/ant_modbus.cpp
@@ -95,7 +95,7 @@ bool AntModbus::parse_ant_modbus_byte_(uint8_t byte) {
   // head add  func val  val  len  data data crc  crc  end  end
   if (address == 0x7E) {
     // Discard new protocol frame for now
-    ESP_LOGD(TAG, "New protocol response frame discarded: %s", format_hex_pretty(raw, at + 1).c_str());
+    ESP_LOGVV(TAG, "New protocol response frame discarded: %s", format_hex_pretty(raw, at + 1).c_str());
     return false;
   }
 

--- a/components/ant_modbus/ant_modbus.cpp
+++ b/components/ant_modbus/ant_modbus.cpp
@@ -203,7 +203,7 @@ void AntModbus::authenticate_v2021_variable_(uint8_t data_len, const uint8_t *da
   data.push_back(0xAA);
   data.push_back(0x55);
 
-  this->write_array(data);
+  this->write_array(data.data(), data.size());
   this->flush();
 }
 

--- a/components/ant_modbus/ant_modbus.cpp
+++ b/components/ant_modbus/ant_modbus.cpp
@@ -191,19 +191,19 @@ void AntModbus::authenticate_v2021_() {
   this->flush();
 }
 
-void AntModbus::authenticate_v2021_variable_(uint8_t data_len, const uint8_t *data) {
-  std::vector<uint8_t> data = {0x7E, 0xA1, 0x23, 0x6A, 0x01};
-  data.push_back(data_len);
+void AntModbus::authenticate_v2021_variable_(const uint8_t *data, uint8_t data_len) {
+  std::vector<uint8_t> frame = {0x7E, 0xA1, 0x23, 0x6A, 0x01};
+  frame.push_back(data_len);
   for (int i = 0; i < data_len; i++) {
-    data.push_back(data[i]);
+    frame.push_back(data[i]);
   }
-  auto crc = crc16(data.data() + 1, data.size());
-  data.push_back(crc >> 0);
-  data.push_back(crc >> 8);
-  data.push_back(0xAA);
-  data.push_back(0x55);
+  auto crc = crc16(frame.data() + 1, frame.size());
+  frame.push_back(crc >> 0);
+  frame.push_back(crc >> 8);
+  frame.push_back(0xAA);
+  frame.push_back(0x55);
 
-  this->write_array(data.data(), data.size());
+  this->write_array(frame.data(), frame.size());
   this->flush();
 }
 

--- a/components/ant_modbus/ant_modbus.cpp
+++ b/components/ant_modbus/ant_modbus.cpp
@@ -95,6 +95,7 @@ bool AntModbus::parse_ant_modbus_byte_(uint8_t byte) {
   // head add  func val  val  len  data data crc  crc  end  end
   if (address == 0x7E) {
     // Discard new protocol frame for now
+    ESP_LOGD(TAG, "New protocol response frame discarded: %s", format_hex_pretty(raw, at + 1).c_str());
     return false;
   }
 

--- a/components/ant_modbus/ant_modbus.h
+++ b/components/ant_modbus/ant_modbus.h
@@ -21,10 +21,12 @@ class AntModbus : public uart::UARTDevice, public Component {
   float get_setup_priority() const override;
 
   void send(uint8_t function, uint8_t address, uint16_t value);
+  void send_v2021(uint8_t function, uint8_t address, uint16_t value);
   void read_registers();
 
  protected:
   bool parse_ant_modbus_byte_(uint8_t byte);
+  void authenticate_v2021_();
 
   std::vector<uint8_t> rx_buffer_;
   uint32_t last_ant_modbus_byte_{0};
@@ -38,6 +40,9 @@ class AntModbusDevice {
   virtual void on_ant_modbus_data(const uint8_t &function, const std::vector<uint8_t> &data) = 0;
 
   void send(uint8_t function, uint8_t address, uint16_t value) { this->parent_->send(function, address, value); }
+  void send_v2021(uint8_t function, uint8_t address, uint16_t value) {
+    this->parent_->send_v2021(function, address, value);
+  }
   void read_registers() { this->parent_->read_registers(); }
 
  protected:

--- a/components/ant_modbus/ant_modbus.h
+++ b/components/ant_modbus/ant_modbus.h
@@ -27,6 +27,7 @@ class AntModbus : public uart::UARTDevice, public Component {
  protected:
   bool parse_ant_modbus_byte_(uint8_t byte);
   void authenticate_v2021_();
+  void authenticate_v2021_variable_(const uint8_t *data, uint8_t data_len);
 
   std::vector<uint8_t> rx_buffer_;
   uint32_t last_ant_modbus_byte_{0};

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -43,8 +43,9 @@ ant_modbus:
 ant_bms:
   id: bms0
   ant_modbus_id: modbus0
-  update_interval: 10s
   password: "${password}"
+  update_interval: 10s
+  supports_new_commands: true
 
 sensor:
   - platform: ant_bms
@@ -168,6 +169,10 @@ switch:
       name: "${name} charging"
     discharging:
       name: "${name} discharging"
+    # BMS version 2021 only
+    # Please enable supports_new_commands
+    balancer:
+      name: "${name} balancer"
 
 button:
   - platform: ant_bms

--- a/esp8266-example-debug.yaml
+++ b/esp8266-example-debug.yaml
@@ -1,0 +1,19 @@
+<<: !include esp8266-example.yaml
+
+logger:
+  baud_rate: 0
+  level: DEBUG
+  logs:
+    api.service: WARN
+    ota: WARN
+    wifi: WARN
+    sensor: DEBUG
+
+uart:
+  id: uart0
+  baud_rate: 19200
+  rx_buffer_size: 384
+  tx_pin: ${tx_pin}
+  rx_pin: ${rx_pin}
+  debug:
+    direction: BOTH

--- a/esp8266-example-faker.yaml
+++ b/esp8266-example-faker.yaml
@@ -1,4 +1,4 @@
-<<: !include esp32-example-debug.yaml
+<<: !include esp8266-example-debug.yaml
 
 ant_bms:
   id: bms0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -3,6 +3,7 @@ substitutions:
   external_components_source: github://syssi/esphome-ant-bms@main
   tx_pin: GPIO1
   rx_pin: GPIO3
+  password: "12345678"
 
 esphome:
   name: ${name}
@@ -43,7 +44,9 @@ ant_modbus:
 ant_bms:
   id: bms0
   ant_modbus_id: modbus0
+  password: "${password}"
   update_interval: 10s
+  supports_new_commands: true
 
 sensor:
   - platform: ant_bms
@@ -167,6 +170,10 @@ switch:
       name: "${name} charging"
     discharging:
       name: "${name} discharging"
+    # BMS version 2021 only
+    # Please enable supports_new_commands
+    balancer:
+      name: "${name} balancer"
 
 button:
   - platform: ant_bms

--- a/test-esp32.sh
+++ b/test-esp32.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+esphome -s external_components_source components ${1:-run} esp32-example-faker.yaml

--- a/test-esp8266.sh
+++ b/test-esp8266.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+esphome -s external_components_source components ${1:-run} esp8266-example-faker.yaml


### PR DESCRIPTION
- [ ] Make password configurable
- [x] Extend frame buffer to avoid invalid header warnings

Please update yaml configuration:

```
ant_bms:
  id: bms0
  ant_modbus_id: modbus0
  password: "${password}"
  update_interval: 10s
  supports_new_commands: true
```

The `supports_new_commands` parameter is important. There are some new switches:

```
switch:
  - platform: ant_bms
    charging:
      name: "${name} charging"
    discharging:
      name: "${name} discharging"
    balancer:
      name: "${name} balancer"
```

And sure to use the feature branch. The new commands aren't official supported/merged yet:

```
external_components:
  - source: github://syssi/esphome-ant-bms@new-protocol-commands
    refresh: 0s
```
