### PR TITLE
Improve total runtime sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ esphome run esp32-example.yaml
 [switch:037]: 'ant-bms charging': Sending state ON
 [switch:037]: 'ant-bms discharging': Sending state ON
 [switch:037]: 'ant-bms balancer': Sending state OFF
+[text_sensor:067]: 'ant-bms total runtime formatted': Sending state '6d 7h '
+[sensor:124]: 'ant-bms total runtime': Sending state 546592.00000 s with 0 decimals of accuracy
 ```
 
 ## Protocol

--- a/components/ant_bms/ant_bms.cpp
+++ b/components/ant_bms/ant_bms.cpp
@@ -119,8 +119,12 @@ void AntBms::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->capacity_remaining_sensor_, (float) ant_get_32bit(79) * 0.000001f);
   //  83    0x00 0x08 0xC7 0x8E: Battery Cycle Capacity                               0.001 Ah
   this->publish_state_(this->battery_cycle_capacity_sensor_, (float) ant_get_32bit(83) * 0.001f);
-  //  87    0x00 0x08 0x57 0x20: Uptime in seconds     546.592 s / 3600 = 151.83 h    s
-  this->publish_state_(this->total_runtime_sensor_, (float) ant_get_32bit(87) / 3600.0f);
+  //  87    0x00 0x08 0x57 0x20: Uptime in seconds     546.592s                       1.0 s
+  this->publish_state_(this->total_runtime_sensor_, (float) ant_get_32bit(87));
+
+  if (this->total_runtime_formatted_text_sensor_ != nullptr) {
+    this->publish_state_(this->total_runtime_formatted_text_sensor_, format_total_runtime_(ant_get_32bit(87)));
+  }
   //  91    0x00 0x15: Temperature 1                   21°C                           1.0 °C
   //  93    0x00 0x15: Temperature 2                   21°C                           1.0 °C
   //  95    0x00 0x14: Temperature 3                   20°C                           1.0 °C
@@ -310,6 +314,7 @@ void AntBms::dump_config() {  // NOLINT(google-readability-function-size,readabi
   LOG_TEXT_SENSOR("", "Discharge Mosfet Status", this->discharge_mosfet_status_text_sensor_);
   LOG_SENSOR("", "Balancer Status Code", this->balancer_status_code_sensor_);
   LOG_TEXT_SENSOR("", "Balancer Status", this->balancer_status_text_sensor_);
+  LOG_TEXT_SENSOR("", "Total Runtime Formatted", this->total_runtime_formatted_text_sensor_);
 }
 
 }  // namespace ant_bms

--- a/components/ant_bms/ant_bms.h
+++ b/components/ant_bms/ant_bms.h
@@ -148,7 +148,7 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
     seconds = seconds % (24 * 3600);
     int hours = seconds / 3600;
     return ((years ? to_string(years) + "y " : "") + (days ? to_string(days) + "d " : "") +
-            (hours ? to_string(hours) + "h " : ""))
+            (hours ? to_string(hours) + "h" : ""))
         .c_str();
   }
 };

--- a/components/ant_bms/ant_bms.h
+++ b/components/ant_bms/ant_bms.h
@@ -148,7 +148,7 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
     seconds = seconds % (24 * 3600);
     int hours = seconds / 3600;
     return (years ? to_string(years) + "y " : "") + (days ? to_string(days) + "d " : "") +
-            (hours ? to_string(hours) + "h" : "");
+           (hours ? to_string(hours) + "h" : "");
   }
 };
 

--- a/components/ant_bms/ant_bms.h
+++ b/components/ant_bms/ant_bms.h
@@ -140,7 +140,7 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
     return (float) (value & 0x7FFFFFFF);
   }
 
-  const std::string format_total_runtime_(const uint32_t value) {
+  std::string format_total_runtime_(const uint32_t value) {
     int seconds = (int) value;
     int years = seconds / (24 * 3600 * 365);
     seconds = seconds % (24 * 3600 * 365);

--- a/components/ant_bms/ant_bms.h
+++ b/components/ant_bms/ant_bms.h
@@ -63,6 +63,9 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
   void set_balancer_status_text_sensor(text_sensor::TextSensor *balancer_status_text_sensor) {
     balancer_status_text_sensor_ = balancer_status_text_sensor;
   }
+  void set_total_runtime_formatted_text_sensor(text_sensor::TextSensor *total_runtime_formatted_text_sensor) {
+    total_runtime_formatted_text_sensor_ = total_runtime_formatted_text_sensor;
+  }
 
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
   void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
@@ -109,6 +112,7 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
   text_sensor::TextSensor *charge_mosfet_status_text_sensor_;
   text_sensor::TextSensor *discharge_mosfet_status_text_sensor_;
   text_sensor::TextSensor *balancer_status_text_sensor_;
+  text_sensor::TextSensor *total_runtime_formatted_text_sensor_;
 
   struct Cell {
     sensor::Sensor *cell_voltage_sensor_{nullptr};
@@ -134,6 +138,18 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
     }
 
     return (float) (value & 0x7FFFFFFF);
+  }
+
+  const std::string format_total_runtime_(const uint32_t value) {
+    int seconds = (int) value;
+    int years = seconds / (24 * 3600 * 365);
+    seconds = seconds % (24 * 3600 * 365);
+    int days = seconds / (24 * 3600);
+    seconds = seconds % (24 * 3600);
+    int hours = seconds / 3600;
+    return ((years ? to_string(years) + "y " : "") + (days ? to_string(days) + "d " : "") +
+            (hours ? to_string(hours) + "h " : ""))
+        .c_str();
   }
 };
 

--- a/components/ant_bms/ant_bms.h
+++ b/components/ant_bms/ant_bms.h
@@ -147,9 +147,8 @@ class AntBms : public PollingComponent, public ant_modbus::AntModbusDevice {
     int days = seconds / (24 * 3600);
     seconds = seconds % (24 * 3600);
     int hours = seconds / 3600;
-    return ((years ? to_string(years) + "y " : "") + (days ? to_string(days) + "d " : "") +
-            (hours ? to_string(hours) + "h" : ""))
-        .c_str();
+    return (years ? to_string(years) + "y " : "") + (days ? to_string(days) + "d " : "") +
+            (hours ? to_string(hours) + "h" : "");
   }
 };
 

--- a/components/ant_bms/sensor.py
+++ b/components/ant_bms/sensor.py
@@ -92,7 +92,7 @@ ICON_CHARGE_MOSFET_STATUS_CODE = "mdi:heart-pulse"
 ICON_DISCHARGE_MOSFET_STATUS_CODE = "mdi:heart-pulse"
 ICON_BALANCER_STATUS_CODE = "mdi:heart-pulse"
 
-UNIT_HOURS = "h"
+UNIT_SECONDS = "s"
 UNIT_AMPERE_HOURS = "Ah"
 
 CELLS = [
@@ -207,9 +207,9 @@ CONFIG_SCHEMA = cv.Schema(
             UNIT_VOLT, ICON_EMPTY, 2, DEVICE_CLASS_VOLTAGE, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional(CONF_TOTAL_RUNTIME): sensor.sensor_schema(
-            UNIT_HOURS,
+            UNIT_SECONDS,
             ICON_TIMELAPSE,
-            2,
+            0,
             DEVICE_CLASS_EMPTY,
             STATE_CLASS_TOTAL_INCREASING,
         ),

--- a/components/ant_bms/text_sensor.py
+++ b/components/ant_bms/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import text_sensor
-from esphome.const import CONF_ICON, CONF_ID
+from esphome.const import CONF_ICON, CONF_ID, ICON_TIMELAPSE
 
 from . import CONF_ANT_BMS_ID, AntBms
 
@@ -12,6 +12,7 @@ CODEOWNERS = ["@syssi"]
 CONF_CHARGE_MOSFET_STATUS = "charge_mosfet_status"
 CONF_DISCHARGE_MOSFET_STATUS = "discharge_mosfet_status"
 CONF_BALANCER_STATUS = "balancer_status"
+CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
 
 ICON_CHARGE_MOSFET_STATUS = "mdi:heart-pulse"
 ICON_DISCHARGE_MOSFET_STATUS = "mdi:heart-pulse"
@@ -21,6 +22,7 @@ TEXT_SENSORS = [
     CONF_CHARGE_MOSFET_STATUS,
     CONF_DISCHARGE_MOSFET_STATUS,
     CONF_BALANCER_STATUS,
+    CONF_TOTAL_RUNTIME_FORMATTED,
 ]
 
 CONFIG_SCHEMA = cv.Schema(
@@ -44,6 +46,14 @@ CONFIG_SCHEMA = cv.Schema(
             {
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
                 cv.Optional(CONF_ICON, default=ICON_BALANCER_STATUS): cv.icon,
+            }
+        ),
+        cv.Optional(
+            CONF_TOTAL_RUNTIME_FORMATTED
+        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                cv.Optional(CONF_ICON, default=ICON_TIMELAPSE): cv.icon,
             }
         ),
     }

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -164,6 +164,8 @@ text_sensor:
       name: "${name} discharge mosfet status"
     balancer_status:
       name: "${name} balancer status"
+    total_runtime_formatted:
+      name: "${name} total runtime formatted"
 
 switch:
   - platform: ant_bms

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -18,13 +18,13 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
-mqtt:
-  broker: !secret mqtt_host
-  username: !secret mqtt_username
-  password: !secret mqtt_password
-  id: mqtt_client
+#mqtt:
+#  broker: !secret mqtt_host
+#  username: !secret mqtt_username
+#  password: !secret mqtt_password
+#  id: mqtt_client
 
-# api:
+api:
 ota:
 logger:
   level: INFO

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -165,6 +165,8 @@ text_sensor:
       name: "${name} discharge mosfet status"
     balancer_status:
       name: "${name} balancer status"
+    total_runtime_formatted:
+      name: "${name} total runtime formatted"
 
 switch:
   - platform: ant_bms

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -18,13 +18,13 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
-#mqtt:
-#  broker: !secret mqtt_host
-#  username: !secret mqtt_username
-#  password: !secret mqtt_password
-#  id: mqtt_client
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
 
-api:
+# api:
 ota:
 logger:
   level: INFO


### PR DESCRIPTION
```
[text_sensor:067]: 'ant-bms total runtime formatted': Sending state '6d 7h'
[sensor:124]: 'ant-bms total runtime': Sending state 546592.00000 s with 0 decimals of accuracy
```