### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ESPHome component to monitor and control a ANT-BMS via UART or BLE
 
 ## Requirements
 
-* [ESPHome 2024.6.0 or higher](https://github.com/esphome/esphome/releases).
+* [ESPHome 2024.12.0 or higher](https://github.com/esphome/esphome/releases).
 * Generic ESP32 or ESP8266 board
 
 ## Schematics

--- a/components/ant_bms/__init__.py
+++ b/components/ant_bms/__init__.py
@@ -38,7 +38,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/components/ant_bms/__init__.py
+++ b/components/ant_bms/__init__.py
@@ -22,7 +22,8 @@ ANT_BMS_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(AntBms),

--- a/components/ant_bms_ble/__init__.py
+++ b/components/ant_bms_ble/__init__.py
@@ -21,7 +21,8 @@ ANT_BMS_BLE_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(AntBmsBle),

--- a/components/ant_bms_ble/__init__.py
+++ b/components/ant_bms_ble/__init__.py
@@ -29,7 +29,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("2s"))
+    .extend(cv.polling_component_schema("2s")),
 )
 
 

--- a/components/ant_bms_old/__init__.py
+++ b/components/ant_bms_old/__init__.py
@@ -37,7 +37,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/components/ant_bms_old/__init__.py
+++ b/components/ant_bms_old/__init__.py
@@ -22,7 +22,8 @@ ANT_BMS_OLD_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(AntBmsOld),

--- a/components/ant_bms_old_ble/__init__.py
+++ b/components/ant_bms_old_ble/__init__.py
@@ -31,7 +31,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("2s"))
+    .extend(cv.polling_component_schema("2s")),
 )
 
 

--- a/components/ant_bms_old_ble/__init__.py
+++ b/components/ant_bms_old_ble/__init__.py
@@ -19,7 +19,8 @@ ANT_BMS_OLD_BLE_COMPONENT_SCHEMA = cv.Schema(
     {cv.GenerateID(CONF_ANT_BMS_OLD_BLE_ID): cv.use_id(AntBmsOldBle)}
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(AntBmsOldBle),

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-ant-bms"
     version: 2.5.0

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,7 +5,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.1.0
   project:
     name: "syssi.esphome-ant-bms"
     version: 2.5.0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-ant-bms"
     version: 2.5.0

--- a/esp32-old-ble-example.yaml
+++ b/esp32-old-ble-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-ant-bms"
     version: 2.5.0

--- a/esp32-old-example.yaml
+++ b/esp32-old-example.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-ant-bms"
     version: 2.5.0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-ant-bms"
     version: 2.5.0

--- a/esp8266-old-example.yaml
+++ b/esp8266-old-example.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-ant-bms"
     version: 2.5.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,7 +6,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-fake-bms-v2021.yaml
+++ b/tests/esp8266-fake-bms-v2021.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-fake-bms.yaml
+++ b/tests/esp8266-fake-bms.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-query-data-v2021.yaml
+++ b/tests/esp8266-query-data-v2021.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-query-data.yaml
+++ b/tests/esp8266-query-data.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-test-protocols.yaml
+++ b/tests/esp8266-test-protocols.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.