### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/ant_bms/button/__init__.py
+++ b/components/ant_bms/button/__init__.py
@@ -42,19 +42,19 @@ CONFIG_SCHEMA = ANT_BMS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_SHUTDOWN): button.button_schema(
             AntButton, icon=ICON_SHUTDOWN
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CLEAR_COUNTER): button.button_schema(
             AntButton, icon=ICON_CLEAR_COUNTER
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_BALANCER): button.button_schema(
             AntButton, icon=ICON_BALANCER
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_FACTORY_RESET): button.button_schema(
             AntButton, icon=ICON_FACTORY_RESET
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RESTART): button.button_schema(
             AntButton, icon=ICON_RESTART
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/ant_bms/button/__init__.py
+++ b/components/ant_bms/button/__init__.py
@@ -40,21 +40,15 @@ AntButton = ant_bms_ns.class_("AntButton", button.Button, cg.Component)
 
 CONFIG_SCHEMA = ANT_BMS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_SHUTDOWN): button.button_schema(
-            AntButton, icon=ICON_SHUTDOWN
-        ),
+        cv.Optional(CONF_SHUTDOWN): button.button_schema(AntButton, icon=ICON_SHUTDOWN),
         cv.Optional(CONF_CLEAR_COUNTER): button.button_schema(
             AntButton, icon=ICON_CLEAR_COUNTER
         ),
-        cv.Optional(CONF_BALANCER): button.button_schema(
-            AntButton, icon=ICON_BALANCER
-        ),
+        cv.Optional(CONF_BALANCER): button.button_schema(AntButton, icon=ICON_BALANCER),
         cv.Optional(CONF_FACTORY_RESET): button.button_schema(
             AntButton, icon=ICON_FACTORY_RESET
         ),
-        cv.Optional(CONF_RESTART): button.button_schema(
-            AntButton, icon=ICON_RESTART
-        ),
+        cv.Optional(CONF_RESTART): button.button_schema(AntButton, icon=ICON_RESTART),
     }
 )
 

--- a/components/ant_bms/switch/__init__.py
+++ b/components/ant_bms/switch/__init__.py
@@ -44,12 +44,8 @@ CONFIG_SCHEMA = ANT_BMS_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_DISCHARGING
         ),
-        cv.Optional(CONF_CHARGING): switch.switch_schema(
-            AntSwitch, icon=ICON_CHARGING
-        ),
-        cv.Optional(CONF_BALANCER): switch.switch_schema(
-            AntSwitch, icon=ICON_BALANCER
-        ),
+        cv.Optional(CONF_CHARGING): switch.switch_schema(AntSwitch, icon=ICON_CHARGING),
+        cv.Optional(CONF_BALANCER): switch.switch_schema(AntSwitch, icon=ICON_BALANCER),
         # cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
         #     AntSwitch, icon=ICON_BLUETOOTH
         # ),

--- a/components/ant_bms/switch/__init__.py
+++ b/components/ant_bms/switch/__init__.py
@@ -43,19 +43,19 @@ CONFIG_SCHEMA = ANT_BMS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_DISCHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_CHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_BALANCER): switch.switch_schema(
             AntSwitch, icon=ICON_BALANCER
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         # cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
         #     AntSwitch, icon=ICON_BLUETOOTH
-        # ).extend(cv.COMPONENT_SCHEMA),
+        # ),
         # cv.Optional(CONF_BUZZER): switch.switch_schema(
         #     AntSwitch, icon=ICON_BUZZER
-        # ).extend(cv.COMPONENT_SCHEMA),
+        # ),
     }
 )
 

--- a/components/ant_bms_ble/button/__init__.py
+++ b/components/ant_bms_ble/button/__init__.py
@@ -53,18 +53,14 @@ AntButton = ant_bms_ble_ns.class_("AntButton", button.Button, cg.Component)
 
 CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_SHUTDOWN): button.button_schema(
-            AntButton, icon=ICON_SHUTDOWN
-        ),
+        cv.Optional(CONF_SHUTDOWN): button.button_schema(AntButton, icon=ICON_SHUTDOWN),
         cv.Optional(CONF_CLEAR_SYSTEM_LOG): button.button_schema(
             AntButton, icon=ICON_CLEAR_SYSTEM_LOG
         ),
         cv.Optional(CONF_FACTORY_RESET): button.button_schema(
             AntButton, icon=ICON_FACTORY_RESET
         ),
-        cv.Optional(CONF_RESTART): button.button_schema(
-            AntButton, icon=ICON_RESTART
-        ),
+        cv.Optional(CONF_RESTART): button.button_schema(AntButton, icon=ICON_RESTART),
     }
 )
 

--- a/components/ant_bms_ble/button/__init__.py
+++ b/components/ant_bms_ble/button/__init__.py
@@ -55,16 +55,16 @@ CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_SHUTDOWN): button.button_schema(
             AntButton, icon=ICON_SHUTDOWN
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CLEAR_SYSTEM_LOG): button.button_schema(
             AntButton, icon=ICON_CLEAR_SYSTEM_LOG
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_FACTORY_RESET): button.button_schema(
             AntButton, icon=ICON_FACTORY_RESET
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RESTART): button.button_schema(
             AntButton, icon=ICON_RESTART
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/ant_bms_ble/switch/__init__.py
+++ b/components/ant_bms_ble/switch/__init__.py
@@ -52,19 +52,19 @@ CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_DISCHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_CHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_BALANCER): switch.switch_schema(
             AntSwitch, icon=ICON_BALANCER
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
             AntSwitch, icon=ICON_BLUETOOTH
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_BUZZER): switch.switch_schema(
             AntSwitch, icon=ICON_BUZZER
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/ant_bms_ble/switch/__init__.py
+++ b/components/ant_bms_ble/switch/__init__.py
@@ -53,18 +53,12 @@ CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_DISCHARGING
         ),
-        cv.Optional(CONF_CHARGING): switch.switch_schema(
-            AntSwitch, icon=ICON_CHARGING
-        ),
-        cv.Optional(CONF_BALANCER): switch.switch_schema(
-            AntSwitch, icon=ICON_BALANCER
-        ),
+        cv.Optional(CONF_CHARGING): switch.switch_schema(AntSwitch, icon=ICON_CHARGING),
+        cv.Optional(CONF_BALANCER): switch.switch_schema(AntSwitch, icon=ICON_BALANCER),
         cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
             AntSwitch, icon=ICON_BLUETOOTH
         ),
-        cv.Optional(CONF_BUZZER): switch.switch_schema(
-            AntSwitch, icon=ICON_BUZZER
-        ),
+        cv.Optional(CONF_BUZZER): switch.switch_schema(AntSwitch, icon=ICON_BUZZER),
     }
 )
 

--- a/components/ant_bms_old/button/__init__.py
+++ b/components/ant_bms_old/button/__init__.py
@@ -40,21 +40,15 @@ AntButton = ant_bms_old_ns.class_("AntButton", button.Button, cg.Component)
 
 CONFIG_SCHEMA = ANT_BMS_OLD_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_SHUTDOWN): button.button_schema(
-            AntButton, icon=ICON_SHUTDOWN
-        ),
+        cv.Optional(CONF_SHUTDOWN): button.button_schema(AntButton, icon=ICON_SHUTDOWN),
         cv.Optional(CONF_CLEAR_COUNTER): button.button_schema(
             AntButton, icon=ICON_CLEAR_COUNTER
         ),
-        cv.Optional(CONF_BALANCER): button.button_schema(
-            AntButton, icon=ICON_BALANCER
-        ),
+        cv.Optional(CONF_BALANCER): button.button_schema(AntButton, icon=ICON_BALANCER),
         cv.Optional(CONF_FACTORY_RESET): button.button_schema(
             AntButton, icon=ICON_FACTORY_RESET
         ),
-        cv.Optional(CONF_RESTART): button.button_schema(
-            AntButton, icon=ICON_RESTART
-        ),
+        cv.Optional(CONF_RESTART): button.button_schema(AntButton, icon=ICON_RESTART),
     }
 )
 

--- a/components/ant_bms_old/button/__init__.py
+++ b/components/ant_bms_old/button/__init__.py
@@ -42,19 +42,19 @@ CONFIG_SCHEMA = ANT_BMS_OLD_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_SHUTDOWN): button.button_schema(
             AntButton, icon=ICON_SHUTDOWN
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CLEAR_COUNTER): button.button_schema(
             AntButton, icon=ICON_CLEAR_COUNTER
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_BALANCER): button.button_schema(
             AntButton, icon=ICON_BALANCER
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_FACTORY_RESET): button.button_schema(
             AntButton, icon=ICON_FACTORY_RESET
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RESTART): button.button_schema(
             AntButton, icon=ICON_RESTART
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/ant_bms_old/switch/__init__.py
+++ b/components/ant_bms_old/switch/__init__.py
@@ -29,9 +29,7 @@ CONFIG_SCHEMA = ANT_BMS_OLD_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_DISCHARGING
         ),
-        cv.Optional(CONF_CHARGING): switch.switch_schema(
-            AntSwitch, icon=ICON_CHARGING
-        ),
+        cv.Optional(CONF_CHARGING): switch.switch_schema(AntSwitch, icon=ICON_CHARGING),
     }
 )
 

--- a/components/ant_bms_old/switch/__init__.py
+++ b/components/ant_bms_old/switch/__init__.py
@@ -28,10 +28,10 @@ CONFIG_SCHEMA = ANT_BMS_OLD_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_DISCHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             AntSwitch, icon=ICON_CHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/ant_bms_old_ble/button/__init__.py
+++ b/components/ant_bms_old_ble/button/__init__.py
@@ -47,23 +47,23 @@ CONFIG_SCHEMA = ANT_BMS_OLD_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_SHUTDOWN): button.button_schema(
             AntButton,
             icon=ICON_SHUTDOWN,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CLEAR_COUNTER): button.button_schema(
             AntButton,
             icon=ICON_CLEAR_COUNTER,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_BALANCER): button.button_schema(
             AntButton,
             icon=ICON_BALANCER,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_FACTORY_RESET): button.button_schema(
             AntButton,
             icon=ICON_FACTORY_RESET,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RESTART): button.button_schema(
             AntButton,
             icon=ICON_RESTART,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/ant_bms_old_ble/switch/__init__.py
+++ b/components/ant_bms_old_ble/switch/__init__.py
@@ -33,11 +33,11 @@ CONFIG_SCHEMA = ANT_BMS_OLD_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             AntSwitch,
             icon=ICON_DISCHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             AntSwitch,
             icon=ICON_CHARGING,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls in all four component variants
- `switch_schema()` and `button_schema()` have included the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant and flagged as unnecessary by static analysis
- Affects `ant_bms`, `ant_bms_ble`, `ant_bms_old`, and `ant_bms_old_ble`