### PR TITLE
Add entity_category to switch schemas

### DIFF
--- a/components/ant_bms/switch/__init__.py
+++ b/components/ant_bms/switch/__init__.py
@@ -1,9 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
-
-from esphome.const import CONF_BLUETOOTH
+from esphome.const import CONF_BLUETOOTH, CONF_ID
 
 from .. import ANT_BMS_COMPONENT_SCHEMA, CONF_ANT_BMS_ID, ant_bms_ns
 from ..const import CONF_BALANCER, CONF_CHARGING, CONF_DISCHARGING

--- a/components/ant_bms_ble/switch/__init__.py
+++ b/components/ant_bms_ble/switch/__init__.py
@@ -1,9 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
-
-from esphome.const import CONF_BLUETOOTH
+from esphome.const import CONF_BLUETOOTH, CONF_ID, ENTITY_CATEGORY_CONFIG
 
 from .. import ANT_BMS_BLE_COMPONENT_SCHEMA, CONF_ANT_BMS_BLE_ID, ant_bms_ble_ns
 from ..const import CONF_BALANCER, CONF_CHARGING, CONF_DISCHARGING
@@ -53,9 +51,15 @@ CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_CHARGING): switch.switch_schema(AntSwitch, icon=ICON_CHARGING),
         cv.Optional(CONF_BALANCER): switch.switch_schema(AntSwitch, icon=ICON_BALANCER),
         cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
-            AntSwitch, icon=ICON_BLUETOOTH
+            AntSwitch,
+            icon=ICON_BLUETOOTH,
+            entity_category=ENTITY_CATEGORY_CONFIG,
         ),
-        cv.Optional(CONF_BUZZER): switch.switch_schema(AntSwitch, icon=ICON_BUZZER),
+        cv.Optional(CONF_BUZZER): switch.switch_schema(
+            AntSwitch,
+            icon=ICON_BUZZER,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
     }
 )
 


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.