### PR TITLE
Initialize BLE char handle members to 0

### DIFF
--- a/components/ant_bms_ble/ant_bms_ble.h
+++ b/components/ant_bms_ble/ant_bms_ble.h
@@ -158,7 +158,7 @@ class AntBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
 
   std::vector<uint8_t> frame_buffer_;
   uint8_t no_response_count_{0};
-  uint16_t characteristic_handle_;
+  uint16_t characteristic_handle_{0};
 
   void on_ant_bms_ble_data_(const uint8_t &function, const std::vector<uint8_t> &data);
   void on_status_data_(const std::vector<uint8_t> &data);

--- a/components/ant_bms_old_ble/ant_bms_old_ble.h
+++ b/components/ant_bms_old_ble/ant_bms_old_ble.h
@@ -147,7 +147,7 @@ class AntBmsOldBle : public esphome::ble_client::BLEClientNode, public PollingCo
 
   std::vector<uint8_t> frame_buffer_;
   uint8_t no_response_count_{0};
-  uint16_t characteristic_handle_;
+  uint16_t characteristic_handle_{0};
 
   void on_ant_bms_old_ble_data_(const uint8_t &function, const std::vector<uint8_t> &data);
   void on_status_data_(const std::vector<uint8_t> &data);


### PR DESCRIPTION
## Summary

- `characteristic_handle_` in both `ant_bms_ble` and `ant_bms_old_ble` was declared without an initializer, leaving it with an indeterminate value from construction until the first BLE connection.
- Adds `{0}` in-class member initializer to guarantee a defined state at construction.