### PR TITLE
Fix text_sensor_schema positional arg and add diagnostic entity categories

### DIFF
--- a/components/ant_bms/text_sensor.py
+++ b/components/ant_bms/text_sensor.py
@@ -28,16 +28,16 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ANT_BMS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_CHARGE_MOSFET_STATUS
+            icon=ICON_CHARGE_MOSFET_STATUS
         ),
         cv.Optional(CONF_DISCHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_DISCHARGE_MOSFET_STATUS
+            icon=ICON_DISCHARGE_MOSFET_STATUS
         ),
         cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_BALANCER_STATUS
+            icon=ICON_BALANCER_STATUS
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE
         ),
     }
 )

--- a/components/ant_bms_ble/text_sensor.py
+++ b/components/ant_bms_ble/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_TIMELAPSE
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_TIMELAPSE
 
 from . import ANT_BMS_BLE_COMPONENT_SCHEMA, CONF_ANT_BMS_BLE_ID
 
@@ -35,22 +35,24 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_CHARGE_MOSFET_STATUS
+            icon=ICON_CHARGE_MOSFET_STATUS
         ),
         cv.Optional(CONF_DISCHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_DISCHARGE_MOSFET_STATUS
+            icon=ICON_DISCHARGE_MOSFET_STATUS
         ),
         cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_BALANCER_STATUS
+            icon=ICON_BALANCER_STATUS
         ),
         cv.Optional(CONF_DEVICE_MODEL): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_DEVICE_MODEL
+            icon=ICON_DEVICE_MODEL,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_SOFTWARE_VERSION
+            icon=ICON_SOFTWARE_VERSION,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE
         ),
     }
 )

--- a/components/ant_bms_old/text_sensor.py
+++ b/components/ant_bms_old/text_sensor.py
@@ -28,16 +28,16 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ANT_BMS_OLD_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_CHARGE_MOSFET_STATUS
+            icon=ICON_CHARGE_MOSFET_STATUS
         ),
         cv.Optional(CONF_DISCHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_DISCHARGE_MOSFET_STATUS
+            icon=ICON_DISCHARGE_MOSFET_STATUS
         ),
         cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_BALANCER_STATUS
+            icon=ICON_BALANCER_STATUS
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE
         ),
     }
 )

--- a/components/ant_bms_old_ble/text_sensor.py
+++ b/components/ant_bms_old_ble/text_sensor.py
@@ -28,16 +28,16 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ANT_BMS_OLD_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_CHARGE_MOSFET_STATUS
+            icon=ICON_CHARGE_MOSFET_STATUS
         ),
         cv.Optional(CONF_DISCHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_DISCHARGE_MOSFET_STATUS
+            icon=ICON_DISCHARGE_MOSFET_STATUS
         ),
         cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_BALANCER_STATUS
+            icon=ICON_BALANCER_STATUS
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE
         ),
     }
 )


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from all `text_sensor_schema(...)` calls (T1)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC` to diagnostic sensors: `device_model`, `software_version` (T2)

Follows the pattern established in `esphome-tianpower-bms`.