### PR TITLE
Remove redundant device name prefix from entity names

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -76,441 +76,441 @@ binary_sensor:
   - platform: ant_bms_ble
     ant_bms_ble_id: bms0
     online_status:
-      name: "${bms0} online status"
+      name: "online status"
       device_id: device0
 
   - platform: ant_bms_ble
     ant_bms_ble_id: bms1
     online_status:
-      name: "${bms1} online status"
+      name: "online status"
       device_id: device1
 
 sensor:
   - platform: ant_bms_ble
     ant_bms_ble_id: bms0
     battery_strings:
-      name: "${bms0} battery strings"
+      name: "battery strings"
       device_id: device0
     current:
-      name: "${bms0} current"
+      name: "current"
       device_id: device0
     soc:
-      name: "${bms0} soc"
+      name: "soc"
       device_id: device0
     total_battery_capacity_setting:
-      name: "${bms0} total battery capacity setting"
+      name: "total battery capacity setting"
       device_id: device0
     capacity_remaining:
-      name: "${bms0} capacity remaining"
+      name: "capacity remaining"
       device_id: device0
     battery_cycle_capacity:
-      name: "${bms0} battery cycle capacity"
+      name: "battery cycle capacity"
       device_id: device0
     total_voltage:
-      name: "${bms0} total voltage"
+      name: "total voltage"
       device_id: device0
     total_runtime:
-      name: "${bms0} total runtime"
+      name: "total runtime"
       device_id: device0
     average_cell_voltage:
-      name: "${bms0} average cell voltage"
+      name: "average cell voltage"
       device_id: device0
     power:
-      name: "${bms0} power"
+      name: "power"
       device_id: device0
     min_cell_voltage:
-      name: "${bms0} min cell voltage"
+      name: "min cell voltage"
       device_id: device0
     max_cell_voltage:
-      name: "${bms0} max cell voltage"
+      name: "max cell voltage"
       device_id: device0
     min_voltage_cell:
-      name: "${bms0} min voltage cell"
+      name: "min voltage cell"
       device_id: device0
     max_voltage_cell:
-      name: "${bms0} max voltage cell"
+      name: "max voltage cell"
       device_id: device0
     delta_cell_voltage:
-      name: "${bms0} delta cell voltage"
+      name: "delta cell voltage"
       device_id: device0
     temperature_1:
-      name: "${bms0} temperature 1"
+      name: "temperature 1"
       device_id: device0
     temperature_2:
-      name: "${bms0} temperature 2"
+      name: "temperature 2"
       device_id: device0
     temperature_3:
-      name: "${bms0} temperature 3"
+      name: "temperature 3"
       device_id: device0
     temperature_4:
-      name: "${bms0} temperature 4"
+      name: "temperature 4"
       device_id: device0
     temperature_5:
-      name: "${bms0} temperature 5"
+      name: "temperature 5"
       device_id: device0
     temperature_6:
-      name: "${bms0} temperature 6"
+      name: "temperature 6"
       device_id: device0
     cell_voltage_1:
-      name: "${bms0} cell voltage 1"
+      name: "cell voltage 1"
       device_id: device0
     cell_voltage_2:
-      name: "${bms0} cell voltage 2"
+      name: "cell voltage 2"
       device_id: device0
     cell_voltage_3:
-      name: "${bms0} cell voltage 3"
+      name: "cell voltage 3"
       device_id: device0
     cell_voltage_4:
-      name: "${bms0} cell voltage 4"
+      name: "cell voltage 4"
       device_id: device0
     cell_voltage_5:
-      name: "${bms0} cell voltage 5"
+      name: "cell voltage 5"
       device_id: device0
     cell_voltage_6:
-      name: "${bms0} cell voltage 6"
+      name: "cell voltage 6"
       device_id: device0
     cell_voltage_7:
-      name: "${bms0} cell voltage 7"
+      name: "cell voltage 7"
       device_id: device0
     cell_voltage_8:
-      name: "${bms0} cell voltage 8"
+      name: "cell voltage 8"
       device_id: device0
     cell_voltage_9:
-      name: "${bms0} cell voltage 9"
+      name: "cell voltage 9"
       device_id: device0
     cell_voltage_10:
-      name: "${bms0} cell voltage 10"
+      name: "cell voltage 10"
       device_id: device0
     cell_voltage_11:
-      name: "${bms0} cell voltage 11"
+      name: "cell voltage 11"
       device_id: device0
     cell_voltage_12:
-      name: "${bms0} cell voltage 12"
+      name: "cell voltage 12"
       device_id: device0
     cell_voltage_13:
-      name: "${bms0} cell voltage 13"
+      name: "cell voltage 13"
       device_id: device0
     cell_voltage_14:
-      name: "${bms0} cell voltage 14"
+      name: "cell voltage 14"
       device_id: device0
     cell_voltage_15:
-      name: "${bms0} cell voltage 15"
+      name: "cell voltage 15"
       device_id: device0
     cell_voltage_16:
-      name: "${bms0} cell voltage 16"
+      name: "cell voltage 16"
       device_id: device0
     cell_voltage_17:
-      name: "${bms0} cell voltage 17"
+      name: "cell voltage 17"
       device_id: device0
     cell_voltage_18:
-      name: "${bms0} cell voltage 18"
+      name: "cell voltage 18"
       device_id: device0
     cell_voltage_19:
-      name: "${bms0} cell voltage 19"
+      name: "cell voltage 19"
       device_id: device0
     cell_voltage_20:
-      name: "${bms0} cell voltage 20"
+      name: "cell voltage 20"
       device_id: device0
     cell_voltage_21:
-      name: "${bms0} cell voltage 21"
+      name: "cell voltage 21"
       device_id: device0
     cell_voltage_22:
-      name: "${bms0} cell voltage 22"
+      name: "cell voltage 22"
       device_id: device0
     cell_voltage_23:
-      name: "${bms0} cell voltage 23"
+      name: "cell voltage 23"
       device_id: device0
     cell_voltage_24:
-      name: "${bms0} cell voltage 24"
+      name: "cell voltage 24"
       device_id: device0
     cell_voltage_25:
-      name: "${bms0} cell voltage 25"
+      name: "cell voltage 25"
       device_id: device0
     cell_voltage_26:
-      name: "${bms0} cell voltage 26"
+      name: "cell voltage 26"
       device_id: device0
     cell_voltage_27:
-      name: "${bms0} cell voltage 27"
+      name: "cell voltage 27"
       device_id: device0
     cell_voltage_28:
-      name: "${bms0} cell voltage 28"
+      name: "cell voltage 28"
       device_id: device0
     cell_voltage_29:
-      name: "${bms0} cell voltage 29"
+      name: "cell voltage 29"
       device_id: device0
     cell_voltage_30:
-      name: "${bms0} cell voltage 30"
+      name: "cell voltage 30"
       device_id: device0
     cell_voltage_31:
-      name: "${bms0} cell voltage 31"
+      name: "cell voltage 31"
       device_id: device0
     cell_voltage_32:
-      name: "${bms0} cell voltage 32"
+      name: "cell voltage 32"
       device_id: device0
     charge_mosfet_status_code:
-      name: "${bms0} charge mosfet status code"
+      name: "charge mosfet status code"
       device_id: device0
     discharge_mosfet_status_code:
-      name: "${bms0} discharge mosfet status code"
+      name: "discharge mosfet status code"
       device_id: device0
     balancer_status_code:
-      name: "${bms0} balancer status code"
+      name: "balancer status code"
       device_id: device0
 
   - platform: ant_bms_ble
     ant_bms_ble_id: bms1
     battery_strings:
-      name: "${bms1} battery strings"
+      name: "battery strings"
       device_id: device1
     current:
-      name: "${bms1} current"
+      name: "current"
       device_id: device1
     soc:
-      name: "${bms1} soc"
+      name: "soc"
       device_id: device1
     total_battery_capacity_setting:
-      name: "${bms1} total battery capacity setting"
+      name: "total battery capacity setting"
       device_id: device1
     capacity_remaining:
-      name: "${bms1} capacity remaining"
+      name: "capacity remaining"
       device_id: device1
     battery_cycle_capacity:
-      name: "${bms1} battery cycle capacity"
+      name: "battery cycle capacity"
       device_id: device1
     total_voltage:
-      name: "${bms1} total voltage"
+      name: "total voltage"
       device_id: device1
     total_runtime:
-      name: "${bms1} total runtime"
+      name: "total runtime"
       device_id: device1
     average_cell_voltage:
-      name: "${bms1} average cell voltage"
+      name: "average cell voltage"
       device_id: device1
     power:
-      name: "${bms1} power"
+      name: "power"
       device_id: device1
     min_cell_voltage:
-      name: "${bms1} min cell voltage"
+      name: "min cell voltage"
       device_id: device1
     max_cell_voltage:
-      name: "${bms1} max cell voltage"
+      name: "max cell voltage"
       device_id: device1
     min_voltage_cell:
-      name: "${bms1} min voltage cell"
+      name: "min voltage cell"
       device_id: device1
     max_voltage_cell:
-      name: "${bms1} max voltage cell"
+      name: "max voltage cell"
       device_id: device1
     delta_cell_voltage:
-      name: "${bms1} delta cell voltage"
+      name: "delta cell voltage"
       device_id: device1
     temperature_1:
-      name: "${bms1} temperature 1"
+      name: "temperature 1"
       device_id: device1
     temperature_2:
-      name: "${bms1} temperature 2"
+      name: "temperature 2"
       device_id: device1
     temperature_3:
-      name: "${bms1} temperature 3"
+      name: "temperature 3"
       device_id: device1
     temperature_4:
-      name: "${bms1} temperature 4"
+      name: "temperature 4"
       device_id: device1
     temperature_5:
-      name: "${bms1} temperature 5"
+      name: "temperature 5"
       device_id: device1
     temperature_6:
-      name: "${bms1} temperature 6"
+      name: "temperature 6"
       device_id: device1
     cell_voltage_1:
-      name: "${bms1} cell voltage 1"
+      name: "cell voltage 1"
       device_id: device1
     cell_voltage_2:
-      name: "${bms1} cell voltage 2"
+      name: "cell voltage 2"
       device_id: device1
     cell_voltage_3:
-      name: "${bms1} cell voltage 3"
+      name: "cell voltage 3"
       device_id: device1
     cell_voltage_4:
-      name: "${bms1} cell voltage 4"
+      name: "cell voltage 4"
       device_id: device1
     cell_voltage_5:
-      name: "${bms1} cell voltage 5"
+      name: "cell voltage 5"
       device_id: device1
     cell_voltage_6:
-      name: "${bms1} cell voltage 6"
+      name: "cell voltage 6"
       device_id: device1
     cell_voltage_7:
-      name: "${bms1} cell voltage 7"
+      name: "cell voltage 7"
       device_id: device1
     cell_voltage_8:
-      name: "${bms1} cell voltage 8"
+      name: "cell voltage 8"
       device_id: device1
     cell_voltage_9:
-      name: "${bms1} cell voltage 9"
+      name: "cell voltage 9"
       device_id: device1
     cell_voltage_10:
-      name: "${bms1} cell voltage 10"
+      name: "cell voltage 10"
       device_id: device1
     cell_voltage_11:
-      name: "${bms1} cell voltage 11"
+      name: "cell voltage 11"
       device_id: device1
     cell_voltage_12:
-      name: "${bms1} cell voltage 12"
+      name: "cell voltage 12"
       device_id: device1
     cell_voltage_13:
-      name: "${bms1} cell voltage 13"
+      name: "cell voltage 13"
       device_id: device1
     cell_voltage_14:
-      name: "${bms1} cell voltage 14"
+      name: "cell voltage 14"
       device_id: device1
     cell_voltage_15:
-      name: "${bms1} cell voltage 15"
+      name: "cell voltage 15"
       device_id: device1
     cell_voltage_16:
-      name: "${bms1} cell voltage 16"
+      name: "cell voltage 16"
       device_id: device1
     cell_voltage_17:
-      name: "${bms1} cell voltage 17"
+      name: "cell voltage 17"
       device_id: device1
     cell_voltage_18:
-      name: "${bms1} cell voltage 18"
+      name: "cell voltage 18"
       device_id: device1
     cell_voltage_19:
-      name: "${bms1} cell voltage 19"
+      name: "cell voltage 19"
       device_id: device1
     cell_voltage_20:
-      name: "${bms1} cell voltage 20"
+      name: "cell voltage 20"
       device_id: device1
     cell_voltage_21:
-      name: "${bms1} cell voltage 21"
+      name: "cell voltage 21"
       device_id: device1
     cell_voltage_22:
-      name: "${bms1} cell voltage 22"
+      name: "cell voltage 22"
       device_id: device1
     cell_voltage_23:
-      name: "${bms1} cell voltage 23"
+      name: "cell voltage 23"
       device_id: device1
     cell_voltage_24:
-      name: "${bms1} cell voltage 24"
+      name: "cell voltage 24"
       device_id: device1
     cell_voltage_25:
-      name: "${bms1} cell voltage 25"
+      name: "cell voltage 25"
       device_id: device1
     cell_voltage_26:
-      name: "${bms1} cell voltage 26"
+      name: "cell voltage 26"
       device_id: device1
     cell_voltage_27:
-      name: "${bms1} cell voltage 27"
+      name: "cell voltage 27"
       device_id: device1
     cell_voltage_28:
-      name: "${bms1} cell voltage 28"
+      name: "cell voltage 28"
       device_id: device1
     cell_voltage_29:
-      name: "${bms1} cell voltage 29"
+      name: "cell voltage 29"
       device_id: device1
     cell_voltage_30:
-      name: "${bms1} cell voltage 30"
+      name: "cell voltage 30"
       device_id: device1
     cell_voltage_31:
-      name: "${bms1} cell voltage 31"
+      name: "cell voltage 31"
       device_id: device1
     cell_voltage_32:
-      name: "${bms1} cell voltage 32"
+      name: "cell voltage 32"
       device_id: device1
     charge_mosfet_status_code:
-      name: "${bms1} charge mosfet status code"
+      name: "charge mosfet status code"
       device_id: device1
     discharge_mosfet_status_code:
-      name: "${bms1} discharge mosfet status code"
+      name: "discharge mosfet status code"
       device_id: device1
     balancer_status_code:
-      name: "${bms1} balancer status code"
+      name: "balancer status code"
       device_id: device1
 
 text_sensor:
   - platform: ant_bms_ble
     ant_bms_ble_id: bms0
     charge_mosfet_status:
-      name: "${bms0} charge mosfet status"
+      name: "charge mosfet status"
       device_id: device0
     discharge_mosfet_status:
-      name: "${bms0} discharge mosfet status"
+      name: "discharge mosfet status"
       device_id: device0
     balancer_status:
-      name: "${bms0} balancer status"
+      name: "balancer status"
       device_id: device0
     total_runtime_formatted:
-      name: "${bms0} total runtime formatted"
+      name: "total runtime formatted"
       device_id: device0
     device_model:
-      name: "${bms0} device model"
+      name: "device model"
       device_id: device0
     software_version:
-      name: "${bms0} software version"
+      name: "software version"
       device_id: device0
 
   - platform: ant_bms_ble
     ant_bms_ble_id: bms1
     charge_mosfet_status:
-      name: "${bms1} charge mosfet status"
+      name: "charge mosfet status"
       device_id: device1
     discharge_mosfet_status:
-      name: "${bms1} discharge mosfet status"
+      name: "discharge mosfet status"
       device_id: device1
     balancer_status:
-      name: "${bms1} balancer status"
+      name: "balancer status"
       device_id: device1
     total_runtime_formatted:
-      name: "${bms1} total runtime formatted"
+      name: "total runtime formatted"
       device_id: device1
     device_model:
-      name: "${bms1} device model"
+      name: "device model"
       device_id: device1
     software_version:
-      name: "${bms1} software version"
+      name: "software version"
       device_id: device1
 
 switch:
   - platform: ant_bms_ble
     ant_bms_ble_id: bms0
     charging:
-      name: "${bms0} charging"
+      name: "charging"
       device_id: device0
     discharging:
-      name: "${bms0} discharging"
+      name: "discharging"
       device_id: device0
     balancer:
-      name: "${bms0} balancer"
+      name: "balancer"
       device_id: device0
     buzzer:
-      name: "${bms0} buzzer"
+      name: "buzzer"
       device_id: device0
 
   - platform: ant_bms_ble
     ant_bms_ble_id: bms1
     charging:
-      name: "${bms1} charging"
+      name: "charging"
       device_id: device1
     discharging:
-      name: "${bms1} discharging"
+      name: "discharging"
       device_id: device1
     balancer:
-      name: "${bms1} balancer"
+      name: "balancer"
       device_id: device1
     buzzer:
-      name: "${bms1} buzzer"
+      name: "buzzer"
       device_id: device1
 
   - platform: ble_client
     ble_client_id: client0
-    name: "${bms0} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
     device_id: device0
 
   - platform: ble_client
     ble_client_id: client1
-    name: "${bms1} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch1
     device_id: device1
 
@@ -518,29 +518,29 @@ button:
   - platform: ant_bms_ble
     ant_bms_ble_id: bms0
     shutdown:
-      name: "${bms0} shutdown"
+      name: "shutdown"
       device_id: device0
     clear_system_log:
-      name: "${bms0} clear system log"
+      name: "clear system log"
       device_id: device0
     factory_reset:
-      name: "${bms0} factory reset"
+      name: "factory reset"
       device_id: device0
     restart:
-      name: "${bms0} restart"
+      name: "restart"
       device_id: device0
 
   - platform: ant_bms_ble
     ant_bms_ble_id: bms1
     shutdown:
-      name: "${bms1} shutdown"
+      name: "shutdown"
       device_id: device1
     clear_system_log:
-      name: "${bms1} clear system log"
+      name: "clear system log"
       device_id: device1
     factory_reset:
-      name: "${bms1} factory reset"
+      name: "factory reset"
       device_id: device1
     restart:
-      name: "${bms1} restart"
+      name: "restart"
       device_id: device1

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -1,0 +1,546 @@
+substitutions:
+  name: ant-bms-ble
+  bms0: "${name} bms0"
+  bms1: "${name} bms1"
+  device_description: "Monitor and control a ANT Battery Management System (ANT-BMS) via BLE"
+  external_components_source: github://syssi/esphome-ant-bms@main
+  bms0_mac_address: 16:aa:22:02:23:45
+  bms1_mac_address: 16:aa:22:02:23:46
+
+esphome:
+  name: ${name}
+  friendly_name: ${name}
+  comment: ${device_description}
+  project:
+    name: "syssi.esphome-ant-bms"
+    version: 2.5.0
+  devices:
+    - id: device0
+      name: "${bms0}"
+    - id: device1
+      name: "${bms1}"
+
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+  on_begin:
+    then:
+      - switch.turn_off: ble_client_switch0
+      - switch.turn_off: ble_client_switch1
+      - logger.log: "BLE connection suspended for OTA update"
+
+logger:
+  level: DEBUG
+
+# If you use Home Assistant please remove this `mqtt` section and uncomment the `api` component!
+# The native API has many advantages over MQTT: https://esphome.io/components/api.html#advantages-over-mqtt
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
+
+# api:
+
+esp32_ble_tracker:
+  scan_parameters:
+    active: false
+
+ble_client:
+  - mac_address: ${bms0_mac_address}
+    id: client0
+  - mac_address: ${bms1_mac_address}
+    id: client1
+
+ant_bms_ble:
+  - id: bms0
+    ble_client_id: client0
+    update_interval: 5s
+  - id: bms1
+    ble_client_id: client1
+    update_interval: 5s
+
+binary_sensor:
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms0
+    online_status:
+      name: "${bms0} online status"
+      device_id: device0
+
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms1
+    online_status:
+      name: "${bms1} online status"
+      device_id: device1
+
+sensor:
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms0
+    battery_strings:
+      name: "${bms0} battery strings"
+      device_id: device0
+    current:
+      name: "${bms0} current"
+      device_id: device0
+    soc:
+      name: "${bms0} soc"
+      device_id: device0
+    total_battery_capacity_setting:
+      name: "${bms0} total battery capacity setting"
+      device_id: device0
+    capacity_remaining:
+      name: "${bms0} capacity remaining"
+      device_id: device0
+    battery_cycle_capacity:
+      name: "${bms0} battery cycle capacity"
+      device_id: device0
+    total_voltage:
+      name: "${bms0} total voltage"
+      device_id: device0
+    total_runtime:
+      name: "${bms0} total runtime"
+      device_id: device0
+    average_cell_voltage:
+      name: "${bms0} average cell voltage"
+      device_id: device0
+    power:
+      name: "${bms0} power"
+      device_id: device0
+    min_cell_voltage:
+      name: "${bms0} min cell voltage"
+      device_id: device0
+    max_cell_voltage:
+      name: "${bms0} max cell voltage"
+      device_id: device0
+    min_voltage_cell:
+      name: "${bms0} min voltage cell"
+      device_id: device0
+    max_voltage_cell:
+      name: "${bms0} max voltage cell"
+      device_id: device0
+    delta_cell_voltage:
+      name: "${bms0} delta cell voltage"
+      device_id: device0
+    temperature_1:
+      name: "${bms0} temperature 1"
+      device_id: device0
+    temperature_2:
+      name: "${bms0} temperature 2"
+      device_id: device0
+    temperature_3:
+      name: "${bms0} temperature 3"
+      device_id: device0
+    temperature_4:
+      name: "${bms0} temperature 4"
+      device_id: device0
+    temperature_5:
+      name: "${bms0} temperature 5"
+      device_id: device0
+    temperature_6:
+      name: "${bms0} temperature 6"
+      device_id: device0
+    cell_voltage_1:
+      name: "${bms0} cell voltage 1"
+      device_id: device0
+    cell_voltage_2:
+      name: "${bms0} cell voltage 2"
+      device_id: device0
+    cell_voltage_3:
+      name: "${bms0} cell voltage 3"
+      device_id: device0
+    cell_voltage_4:
+      name: "${bms0} cell voltage 4"
+      device_id: device0
+    cell_voltage_5:
+      name: "${bms0} cell voltage 5"
+      device_id: device0
+    cell_voltage_6:
+      name: "${bms0} cell voltage 6"
+      device_id: device0
+    cell_voltage_7:
+      name: "${bms0} cell voltage 7"
+      device_id: device0
+    cell_voltage_8:
+      name: "${bms0} cell voltage 8"
+      device_id: device0
+    cell_voltage_9:
+      name: "${bms0} cell voltage 9"
+      device_id: device0
+    cell_voltage_10:
+      name: "${bms0} cell voltage 10"
+      device_id: device0
+    cell_voltage_11:
+      name: "${bms0} cell voltage 11"
+      device_id: device0
+    cell_voltage_12:
+      name: "${bms0} cell voltage 12"
+      device_id: device0
+    cell_voltage_13:
+      name: "${bms0} cell voltage 13"
+      device_id: device0
+    cell_voltage_14:
+      name: "${bms0} cell voltage 14"
+      device_id: device0
+    cell_voltage_15:
+      name: "${bms0} cell voltage 15"
+      device_id: device0
+    cell_voltage_16:
+      name: "${bms0} cell voltage 16"
+      device_id: device0
+    cell_voltage_17:
+      name: "${bms0} cell voltage 17"
+      device_id: device0
+    cell_voltage_18:
+      name: "${bms0} cell voltage 18"
+      device_id: device0
+    cell_voltage_19:
+      name: "${bms0} cell voltage 19"
+      device_id: device0
+    cell_voltage_20:
+      name: "${bms0} cell voltage 20"
+      device_id: device0
+    cell_voltage_21:
+      name: "${bms0} cell voltage 21"
+      device_id: device0
+    cell_voltage_22:
+      name: "${bms0} cell voltage 22"
+      device_id: device0
+    cell_voltage_23:
+      name: "${bms0} cell voltage 23"
+      device_id: device0
+    cell_voltage_24:
+      name: "${bms0} cell voltage 24"
+      device_id: device0
+    cell_voltage_25:
+      name: "${bms0} cell voltage 25"
+      device_id: device0
+    cell_voltage_26:
+      name: "${bms0} cell voltage 26"
+      device_id: device0
+    cell_voltage_27:
+      name: "${bms0} cell voltage 27"
+      device_id: device0
+    cell_voltage_28:
+      name: "${bms0} cell voltage 28"
+      device_id: device0
+    cell_voltage_29:
+      name: "${bms0} cell voltage 29"
+      device_id: device0
+    cell_voltage_30:
+      name: "${bms0} cell voltage 30"
+      device_id: device0
+    cell_voltage_31:
+      name: "${bms0} cell voltage 31"
+      device_id: device0
+    cell_voltage_32:
+      name: "${bms0} cell voltage 32"
+      device_id: device0
+    charge_mosfet_status_code:
+      name: "${bms0} charge mosfet status code"
+      device_id: device0
+    discharge_mosfet_status_code:
+      name: "${bms0} discharge mosfet status code"
+      device_id: device0
+    balancer_status_code:
+      name: "${bms0} balancer status code"
+      device_id: device0
+
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms1
+    battery_strings:
+      name: "${bms1} battery strings"
+      device_id: device1
+    current:
+      name: "${bms1} current"
+      device_id: device1
+    soc:
+      name: "${bms1} soc"
+      device_id: device1
+    total_battery_capacity_setting:
+      name: "${bms1} total battery capacity setting"
+      device_id: device1
+    capacity_remaining:
+      name: "${bms1} capacity remaining"
+      device_id: device1
+    battery_cycle_capacity:
+      name: "${bms1} battery cycle capacity"
+      device_id: device1
+    total_voltage:
+      name: "${bms1} total voltage"
+      device_id: device1
+    total_runtime:
+      name: "${bms1} total runtime"
+      device_id: device1
+    average_cell_voltage:
+      name: "${bms1} average cell voltage"
+      device_id: device1
+    power:
+      name: "${bms1} power"
+      device_id: device1
+    min_cell_voltage:
+      name: "${bms1} min cell voltage"
+      device_id: device1
+    max_cell_voltage:
+      name: "${bms1} max cell voltage"
+      device_id: device1
+    min_voltage_cell:
+      name: "${bms1} min voltage cell"
+      device_id: device1
+    max_voltage_cell:
+      name: "${bms1} max voltage cell"
+      device_id: device1
+    delta_cell_voltage:
+      name: "${bms1} delta cell voltage"
+      device_id: device1
+    temperature_1:
+      name: "${bms1} temperature 1"
+      device_id: device1
+    temperature_2:
+      name: "${bms1} temperature 2"
+      device_id: device1
+    temperature_3:
+      name: "${bms1} temperature 3"
+      device_id: device1
+    temperature_4:
+      name: "${bms1} temperature 4"
+      device_id: device1
+    temperature_5:
+      name: "${bms1} temperature 5"
+      device_id: device1
+    temperature_6:
+      name: "${bms1} temperature 6"
+      device_id: device1
+    cell_voltage_1:
+      name: "${bms1} cell voltage 1"
+      device_id: device1
+    cell_voltage_2:
+      name: "${bms1} cell voltage 2"
+      device_id: device1
+    cell_voltage_3:
+      name: "${bms1} cell voltage 3"
+      device_id: device1
+    cell_voltage_4:
+      name: "${bms1} cell voltage 4"
+      device_id: device1
+    cell_voltage_5:
+      name: "${bms1} cell voltage 5"
+      device_id: device1
+    cell_voltage_6:
+      name: "${bms1} cell voltage 6"
+      device_id: device1
+    cell_voltage_7:
+      name: "${bms1} cell voltage 7"
+      device_id: device1
+    cell_voltage_8:
+      name: "${bms1} cell voltage 8"
+      device_id: device1
+    cell_voltage_9:
+      name: "${bms1} cell voltage 9"
+      device_id: device1
+    cell_voltage_10:
+      name: "${bms1} cell voltage 10"
+      device_id: device1
+    cell_voltage_11:
+      name: "${bms1} cell voltage 11"
+      device_id: device1
+    cell_voltage_12:
+      name: "${bms1} cell voltage 12"
+      device_id: device1
+    cell_voltage_13:
+      name: "${bms1} cell voltage 13"
+      device_id: device1
+    cell_voltage_14:
+      name: "${bms1} cell voltage 14"
+      device_id: device1
+    cell_voltage_15:
+      name: "${bms1} cell voltage 15"
+      device_id: device1
+    cell_voltage_16:
+      name: "${bms1} cell voltage 16"
+      device_id: device1
+    cell_voltage_17:
+      name: "${bms1} cell voltage 17"
+      device_id: device1
+    cell_voltage_18:
+      name: "${bms1} cell voltage 18"
+      device_id: device1
+    cell_voltage_19:
+      name: "${bms1} cell voltage 19"
+      device_id: device1
+    cell_voltage_20:
+      name: "${bms1} cell voltage 20"
+      device_id: device1
+    cell_voltage_21:
+      name: "${bms1} cell voltage 21"
+      device_id: device1
+    cell_voltage_22:
+      name: "${bms1} cell voltage 22"
+      device_id: device1
+    cell_voltage_23:
+      name: "${bms1} cell voltage 23"
+      device_id: device1
+    cell_voltage_24:
+      name: "${bms1} cell voltage 24"
+      device_id: device1
+    cell_voltage_25:
+      name: "${bms1} cell voltage 25"
+      device_id: device1
+    cell_voltage_26:
+      name: "${bms1} cell voltage 26"
+      device_id: device1
+    cell_voltage_27:
+      name: "${bms1} cell voltage 27"
+      device_id: device1
+    cell_voltage_28:
+      name: "${bms1} cell voltage 28"
+      device_id: device1
+    cell_voltage_29:
+      name: "${bms1} cell voltage 29"
+      device_id: device1
+    cell_voltage_30:
+      name: "${bms1} cell voltage 30"
+      device_id: device1
+    cell_voltage_31:
+      name: "${bms1} cell voltage 31"
+      device_id: device1
+    cell_voltage_32:
+      name: "${bms1} cell voltage 32"
+      device_id: device1
+    charge_mosfet_status_code:
+      name: "${bms1} charge mosfet status code"
+      device_id: device1
+    discharge_mosfet_status_code:
+      name: "${bms1} discharge mosfet status code"
+      device_id: device1
+    balancer_status_code:
+      name: "${bms1} balancer status code"
+      device_id: device1
+
+text_sensor:
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms0
+    charge_mosfet_status:
+      name: "${bms0} charge mosfet status"
+      device_id: device0
+    discharge_mosfet_status:
+      name: "${bms0} discharge mosfet status"
+      device_id: device0
+    balancer_status:
+      name: "${bms0} balancer status"
+      device_id: device0
+    total_runtime_formatted:
+      name: "${bms0} total runtime formatted"
+      device_id: device0
+    device_model:
+      name: "${bms0} device model"
+      device_id: device0
+    software_version:
+      name: "${bms0} software version"
+      device_id: device0
+
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms1
+    charge_mosfet_status:
+      name: "${bms1} charge mosfet status"
+      device_id: device1
+    discharge_mosfet_status:
+      name: "${bms1} discharge mosfet status"
+      device_id: device1
+    balancer_status:
+      name: "${bms1} balancer status"
+      device_id: device1
+    total_runtime_formatted:
+      name: "${bms1} total runtime formatted"
+      device_id: device1
+    device_model:
+      name: "${bms1} device model"
+      device_id: device1
+    software_version:
+      name: "${bms1} software version"
+      device_id: device1
+
+switch:
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms0
+    charging:
+      name: "${bms0} charging"
+      device_id: device0
+    discharging:
+      name: "${bms0} discharging"
+      device_id: device0
+    balancer:
+      name: "${bms0} balancer"
+      device_id: device0
+    buzzer:
+      name: "${bms0} buzzer"
+      device_id: device0
+
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms1
+    charging:
+      name: "${bms1} charging"
+      device_id: device1
+    discharging:
+      name: "${bms1} discharging"
+      device_id: device1
+    balancer:
+      name: "${bms1} balancer"
+      device_id: device1
+    buzzer:
+      name: "${bms1} buzzer"
+      device_id: device1
+
+  - platform: ble_client
+    ble_client_id: client0
+    name: "${bms0} enable bluetooth connection"
+    id: ble_client_switch0
+    device_id: device0
+
+  - platform: ble_client
+    ble_client_id: client1
+    name: "${bms1} enable bluetooth connection"
+    id: ble_client_switch1
+    device_id: device1
+
+button:
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms0
+    shutdown:
+      name: "${bms0} shutdown"
+      device_id: device0
+    clear_system_log:
+      name: "${bms0} clear system log"
+      device_id: device0
+    factory_reset:
+      name: "${bms0} factory reset"
+      device_id: device0
+    restart:
+      name: "${bms0} restart"
+      device_id: device0
+
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms1
+    shutdown:
+      name: "${bms1} shutdown"
+      device_id: device1
+    clear_system_log:
+      name: "${bms1} clear system log"
+      device_id: device1
+    factory_reset:
+      name: "${bms1} factory reset"
+      device_id: device1
+    restart:
+      name: "${bms1} restart"
+      device_id: device1

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -1,0 +1,533 @@
+substitutions:
+  name: ant-bms
+  bms0: "${name} bms0"
+  bms1: "${name} bms1"
+  device_description: "Monitor and control two ANT Battery Management Systems (ANT-BMS) via UART"
+  external_components_source: github://syssi/esphome-ant-bms@main
+  rx_timeout: 50ms
+  tx_pin_uart_0: GPIO16
+  rx_pin_uart_0: GPIO17
+  tx_pin_uart_1: GPIO14
+  rx_pin_uart_1: GPIO4
+  password: "12345678"
+
+esphome:
+  name: ${name}
+  friendly_name: ${name}
+  comment: ${device_description}
+  project:
+    name: "syssi.esphome-ant-bms"
+    version: 2.5.0
+  devices:
+    - id: device0
+      name: "${bms0}"
+    - id: device1
+      name: "${bms1}"
+
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+
+logger:
+  level: DEBUG
+
+# If you use Home Assistant please remove this `mqtt` section and uncomment the `api` component!
+# The native API has many advantages over MQTT: https://esphome.io/components/api.html#advantages-over-mqtt
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
+
+# api:
+
+uart:
+  - id: uart_0
+    baud_rate: 19200
+    rx_buffer_size: 384
+    tx_pin: ${tx_pin_uart_0}
+    rx_pin: ${rx_pin_uart_0}
+  - id: uart_1
+    baud_rate: 19200
+    rx_buffer_size: 384
+    tx_pin: ${tx_pin_uart_1}
+    rx_pin: ${rx_pin_uart_1}
+
+ant_bms:
+  - id: bms0
+    uart_id: uart_0
+    update_interval: 10s
+    rx_timeout: ${rx_timeout}
+    supports_new_commands: true
+    password: "${password}"
+  - id: bms1
+    uart_id: uart_1
+    update_interval: 10s
+    rx_timeout: ${rx_timeout}
+    supports_new_commands: true
+    password: "${password}"
+
+binary_sensor:
+  - platform: ant_bms
+    ant_bms_id: bms0
+    online_status:
+      name: "${bms0} online status"
+      device_id: device0
+
+  - platform: ant_bms
+    ant_bms_id: bms1
+    online_status:
+      name: "${bms1} online status"
+      device_id: device1
+
+sensor:
+  - platform: ant_bms
+    ant_bms_id: bms0
+    battery_strings:
+      name: "${bms0} battery strings"
+      device_id: device0
+    current:
+      name: "${bms0} current"
+      device_id: device0
+    soc:
+      name: "${bms0} soc"
+      device_id: device0
+    total_battery_capacity_setting:
+      name: "${bms0} total battery capacity setting"
+      device_id: device0
+    capacity_remaining:
+      name: "${bms0} capacity remaining"
+      device_id: device0
+    battery_cycle_capacity:
+      name: "${bms0} battery cycle capacity"
+      device_id: device0
+    total_voltage:
+      name: "${bms0} total voltage"
+      device_id: device0
+    total_runtime:
+      name: "${bms0} total runtime"
+      device_id: device0
+    average_cell_voltage:
+      name: "${bms0} average cell voltage"
+      device_id: device0
+    power:
+      name: "${bms0} power"
+      device_id: device0
+    min_cell_voltage:
+      name: "${bms0} min cell voltage"
+      device_id: device0
+    max_cell_voltage:
+      name: "${bms0} max cell voltage"
+      device_id: device0
+    min_voltage_cell:
+      name: "${bms0} min voltage cell"
+      device_id: device0
+    max_voltage_cell:
+      name: "${bms0} max voltage cell"
+      device_id: device0
+    delta_cell_voltage:
+      name: "${bms0} delta cell voltage"
+      device_id: device0
+    temperature_1:
+      name: "${bms0} temperature 1"
+      device_id: device0
+    temperature_2:
+      name: "${bms0} temperature 2"
+      device_id: device0
+    temperature_3:
+      name: "${bms0} temperature 3"
+      device_id: device0
+    temperature_4:
+      name: "${bms0} temperature 4"
+      device_id: device0
+    temperature_5:
+      name: "${bms0} temperature 5"
+      device_id: device0
+    temperature_6:
+      name: "${bms0} temperature 6"
+      device_id: device0
+    cell_voltage_1:
+      name: "${bms0} cell voltage 1"
+      device_id: device0
+    cell_voltage_2:
+      name: "${bms0} cell voltage 2"
+      device_id: device0
+    cell_voltage_3:
+      name: "${bms0} cell voltage 3"
+      device_id: device0
+    cell_voltage_4:
+      name: "${bms0} cell voltage 4"
+      device_id: device0
+    cell_voltage_5:
+      name: "${bms0} cell voltage 5"
+      device_id: device0
+    cell_voltage_6:
+      name: "${bms0} cell voltage 6"
+      device_id: device0
+    cell_voltage_7:
+      name: "${bms0} cell voltage 7"
+      device_id: device0
+    cell_voltage_8:
+      name: "${bms0} cell voltage 8"
+      device_id: device0
+    cell_voltage_9:
+      name: "${bms0} cell voltage 9"
+      device_id: device0
+    cell_voltage_10:
+      name: "${bms0} cell voltage 10"
+      device_id: device0
+    cell_voltage_11:
+      name: "${bms0} cell voltage 11"
+      device_id: device0
+    cell_voltage_12:
+      name: "${bms0} cell voltage 12"
+      device_id: device0
+    cell_voltage_13:
+      name: "${bms0} cell voltage 13"
+      device_id: device0
+    cell_voltage_14:
+      name: "${bms0} cell voltage 14"
+      device_id: device0
+    cell_voltage_15:
+      name: "${bms0} cell voltage 15"
+      device_id: device0
+    cell_voltage_16:
+      name: "${bms0} cell voltage 16"
+      device_id: device0
+    cell_voltage_17:
+      name: "${bms0} cell voltage 17"
+      device_id: device0
+    cell_voltage_18:
+      name: "${bms0} cell voltage 18"
+      device_id: device0
+    cell_voltage_19:
+      name: "${bms0} cell voltage 19"
+      device_id: device0
+    cell_voltage_20:
+      name: "${bms0} cell voltage 20"
+      device_id: device0
+    cell_voltage_21:
+      name: "${bms0} cell voltage 21"
+      device_id: device0
+    cell_voltage_22:
+      name: "${bms0} cell voltage 22"
+      device_id: device0
+    cell_voltage_23:
+      name: "${bms0} cell voltage 23"
+      device_id: device0
+    cell_voltage_24:
+      name: "${bms0} cell voltage 24"
+      device_id: device0
+    cell_voltage_25:
+      name: "${bms0} cell voltage 25"
+      device_id: device0
+    cell_voltage_26:
+      name: "${bms0} cell voltage 26"
+      device_id: device0
+    cell_voltage_27:
+      name: "${bms0} cell voltage 27"
+      device_id: device0
+    cell_voltage_28:
+      name: "${bms0} cell voltage 28"
+      device_id: device0
+    cell_voltage_29:
+      name: "${bms0} cell voltage 29"
+      device_id: device0
+    cell_voltage_30:
+      name: "${bms0} cell voltage 30"
+      device_id: device0
+    cell_voltage_31:
+      name: "${bms0} cell voltage 31"
+      device_id: device0
+    cell_voltage_32:
+      name: "${bms0} cell voltage 32"
+      device_id: device0
+    charge_mosfet_status_code:
+      name: "${bms0} charge mosfet status code"
+      device_id: device0
+    discharge_mosfet_status_code:
+      name: "${bms0} discharge mosfet status code"
+      device_id: device0
+    balancer_status_code:
+      name: "${bms0} balancer status code"
+      device_id: device0
+
+  - platform: ant_bms
+    ant_bms_id: bms1
+    battery_strings:
+      name: "${bms1} battery strings"
+      device_id: device1
+    current:
+      name: "${bms1} current"
+      device_id: device1
+    soc:
+      name: "${bms1} soc"
+      device_id: device1
+    total_battery_capacity_setting:
+      name: "${bms1} total battery capacity setting"
+      device_id: device1
+    capacity_remaining:
+      name: "${bms1} capacity remaining"
+      device_id: device1
+    battery_cycle_capacity:
+      name: "${bms1} battery cycle capacity"
+      device_id: device1
+    total_voltage:
+      name: "${bms1} total voltage"
+      device_id: device1
+    total_runtime:
+      name: "${bms1} total runtime"
+      device_id: device1
+    average_cell_voltage:
+      name: "${bms1} average cell voltage"
+      device_id: device1
+    power:
+      name: "${bms1} power"
+      device_id: device1
+    min_cell_voltage:
+      name: "${bms1} min cell voltage"
+      device_id: device1
+    max_cell_voltage:
+      name: "${bms1} max cell voltage"
+      device_id: device1
+    min_voltage_cell:
+      name: "${bms1} min voltage cell"
+      device_id: device1
+    max_voltage_cell:
+      name: "${bms1} max voltage cell"
+      device_id: device1
+    delta_cell_voltage:
+      name: "${bms1} delta cell voltage"
+      device_id: device1
+    temperature_1:
+      name: "${bms1} temperature 1"
+      device_id: device1
+    temperature_2:
+      name: "${bms1} temperature 2"
+      device_id: device1
+    temperature_3:
+      name: "${bms1} temperature 3"
+      device_id: device1
+    temperature_4:
+      name: "${bms1} temperature 4"
+      device_id: device1
+    temperature_5:
+      name: "${bms1} temperature 5"
+      device_id: device1
+    temperature_6:
+      name: "${bms1} temperature 6"
+      device_id: device1
+    cell_voltage_1:
+      name: "${bms1} cell voltage 1"
+      device_id: device1
+    cell_voltage_2:
+      name: "${bms1} cell voltage 2"
+      device_id: device1
+    cell_voltage_3:
+      name: "${bms1} cell voltage 3"
+      device_id: device1
+    cell_voltage_4:
+      name: "${bms1} cell voltage 4"
+      device_id: device1
+    cell_voltage_5:
+      name: "${bms1} cell voltage 5"
+      device_id: device1
+    cell_voltage_6:
+      name: "${bms1} cell voltage 6"
+      device_id: device1
+    cell_voltage_7:
+      name: "${bms1} cell voltage 7"
+      device_id: device1
+    cell_voltage_8:
+      name: "${bms1} cell voltage 8"
+      device_id: device1
+    cell_voltage_9:
+      name: "${bms1} cell voltage 9"
+      device_id: device1
+    cell_voltage_10:
+      name: "${bms1} cell voltage 10"
+      device_id: device1
+    cell_voltage_11:
+      name: "${bms1} cell voltage 11"
+      device_id: device1
+    cell_voltage_12:
+      name: "${bms1} cell voltage 12"
+      device_id: device1
+    cell_voltage_13:
+      name: "${bms1} cell voltage 13"
+      device_id: device1
+    cell_voltage_14:
+      name: "${bms1} cell voltage 14"
+      device_id: device1
+    cell_voltage_15:
+      name: "${bms1} cell voltage 15"
+      device_id: device1
+    cell_voltage_16:
+      name: "${bms1} cell voltage 16"
+      device_id: device1
+    cell_voltage_17:
+      name: "${bms1} cell voltage 17"
+      device_id: device1
+    cell_voltage_18:
+      name: "${bms1} cell voltage 18"
+      device_id: device1
+    cell_voltage_19:
+      name: "${bms1} cell voltage 19"
+      device_id: device1
+    cell_voltage_20:
+      name: "${bms1} cell voltage 20"
+      device_id: device1
+    cell_voltage_21:
+      name: "${bms1} cell voltage 21"
+      device_id: device1
+    cell_voltage_22:
+      name: "${bms1} cell voltage 22"
+      device_id: device1
+    cell_voltage_23:
+      name: "${bms1} cell voltage 23"
+      device_id: device1
+    cell_voltage_24:
+      name: "${bms1} cell voltage 24"
+      device_id: device1
+    cell_voltage_25:
+      name: "${bms1} cell voltage 25"
+      device_id: device1
+    cell_voltage_26:
+      name: "${bms1} cell voltage 26"
+      device_id: device1
+    cell_voltage_27:
+      name: "${bms1} cell voltage 27"
+      device_id: device1
+    cell_voltage_28:
+      name: "${bms1} cell voltage 28"
+      device_id: device1
+    cell_voltage_29:
+      name: "${bms1} cell voltage 29"
+      device_id: device1
+    cell_voltage_30:
+      name: "${bms1} cell voltage 30"
+      device_id: device1
+    cell_voltage_31:
+      name: "${bms1} cell voltage 31"
+      device_id: device1
+    cell_voltage_32:
+      name: "${bms1} cell voltage 32"
+      device_id: device1
+    charge_mosfet_status_code:
+      name: "${bms1} charge mosfet status code"
+      device_id: device1
+    discharge_mosfet_status_code:
+      name: "${bms1} discharge mosfet status code"
+      device_id: device1
+    balancer_status_code:
+      name: "${bms1} balancer status code"
+      device_id: device1
+
+text_sensor:
+  - platform: ant_bms
+    ant_bms_id: bms0
+    charge_mosfet_status:
+      name: "${bms0} charge mosfet status"
+      device_id: device0
+    discharge_mosfet_status:
+      name: "${bms0} discharge mosfet status"
+      device_id: device0
+    balancer_status:
+      name: "${bms0} balancer status"
+      device_id: device0
+    total_runtime_formatted:
+      name: "${bms0} total runtime formatted"
+      device_id: device0
+
+  - platform: ant_bms
+    ant_bms_id: bms1
+    charge_mosfet_status:
+      name: "${bms1} charge mosfet status"
+      device_id: device1
+    discharge_mosfet_status:
+      name: "${bms1} discharge mosfet status"
+      device_id: device1
+    balancer_status:
+      name: "${bms1} balancer status"
+      device_id: device1
+    total_runtime_formatted:
+      name: "${bms1} total runtime formatted"
+      device_id: device1
+
+switch:
+  - platform: ant_bms
+    ant_bms_id: bms0
+    charging:
+      name: "${bms0} charging"
+      device_id: device0
+    discharging:
+      name: "${bms0} discharging"
+      device_id: device0
+    # BMS version 2021 only
+    # Please enable supports_new_commands
+    balancer:
+      name: "${bms0} balancer"
+      device_id: device0
+
+  - platform: ant_bms
+    ant_bms_id: bms1
+    charging:
+      name: "${bms1} charging"
+      device_id: device1
+    discharging:
+      name: "${bms1} discharging"
+      device_id: device1
+    # BMS version 2021 only
+    # Please enable supports_new_commands
+    balancer:
+      name: "${bms1} balancer"
+      device_id: device1
+
+button:
+  - platform: ant_bms
+    ant_bms_id: bms0
+    shutdown:
+      name: "${bms0} shutdown"
+      device_id: device0
+    clear_counter:
+      name: "${bms0} clear counter"
+      device_id: device0
+    balancer:
+      name: "${bms0} balancer"
+      device_id: device0
+    factory_reset:
+      name: "${bms0} factory reset"
+      device_id: device0
+    restart:
+      name: "${bms0} restart"
+      device_id: device0
+
+  - platform: ant_bms
+    ant_bms_id: bms1
+    shutdown:
+      name: "${bms1} shutdown"
+      device_id: device1
+    clear_counter:
+      name: "${bms1} clear counter"
+      device_id: device1
+    balancer:
+      name: "${bms1} balancer"
+      device_id: device1
+    factory_reset:
+      name: "${bms1} factory reset"
+      device_id: device1
+    restart:
+      name: "${bms1} restart"
+      device_id: device1

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -83,451 +83,451 @@ binary_sensor:
   - platform: ant_bms
     ant_bms_id: bms0
     online_status:
-      name: "${bms0} online status"
+      name: "online status"
       device_id: device0
 
   - platform: ant_bms
     ant_bms_id: bms1
     online_status:
-      name: "${bms1} online status"
+      name: "online status"
       device_id: device1
 
 sensor:
   - platform: ant_bms
     ant_bms_id: bms0
     battery_strings:
-      name: "${bms0} battery strings"
+      name: "battery strings"
       device_id: device0
     current:
-      name: "${bms0} current"
+      name: "current"
       device_id: device0
     soc:
-      name: "${bms0} soc"
+      name: "soc"
       device_id: device0
     total_battery_capacity_setting:
-      name: "${bms0} total battery capacity setting"
+      name: "total battery capacity setting"
       device_id: device0
     capacity_remaining:
-      name: "${bms0} capacity remaining"
+      name: "capacity remaining"
       device_id: device0
     battery_cycle_capacity:
-      name: "${bms0} battery cycle capacity"
+      name: "battery cycle capacity"
       device_id: device0
     total_voltage:
-      name: "${bms0} total voltage"
+      name: "total voltage"
       device_id: device0
     total_runtime:
-      name: "${bms0} total runtime"
+      name: "total runtime"
       device_id: device0
     average_cell_voltage:
-      name: "${bms0} average cell voltage"
+      name: "average cell voltage"
       device_id: device0
     power:
-      name: "${bms0} power"
+      name: "power"
       device_id: device0
     min_cell_voltage:
-      name: "${bms0} min cell voltage"
+      name: "min cell voltage"
       device_id: device0
     max_cell_voltage:
-      name: "${bms0} max cell voltage"
+      name: "max cell voltage"
       device_id: device0
     min_voltage_cell:
-      name: "${bms0} min voltage cell"
+      name: "min voltage cell"
       device_id: device0
     max_voltage_cell:
-      name: "${bms0} max voltage cell"
+      name: "max voltage cell"
       device_id: device0
     delta_cell_voltage:
-      name: "${bms0} delta cell voltage"
+      name: "delta cell voltage"
       device_id: device0
     temperature_1:
-      name: "${bms0} temperature 1"
+      name: "temperature 1"
       device_id: device0
     temperature_2:
-      name: "${bms0} temperature 2"
+      name: "temperature 2"
       device_id: device0
     temperature_3:
-      name: "${bms0} temperature 3"
+      name: "temperature 3"
       device_id: device0
     temperature_4:
-      name: "${bms0} temperature 4"
+      name: "temperature 4"
       device_id: device0
     temperature_5:
-      name: "${bms0} temperature 5"
+      name: "temperature 5"
       device_id: device0
     temperature_6:
-      name: "${bms0} temperature 6"
+      name: "temperature 6"
       device_id: device0
     cell_voltage_1:
-      name: "${bms0} cell voltage 1"
+      name: "cell voltage 1"
       device_id: device0
     cell_voltage_2:
-      name: "${bms0} cell voltage 2"
+      name: "cell voltage 2"
       device_id: device0
     cell_voltage_3:
-      name: "${bms0} cell voltage 3"
+      name: "cell voltage 3"
       device_id: device0
     cell_voltage_4:
-      name: "${bms0} cell voltage 4"
+      name: "cell voltage 4"
       device_id: device0
     cell_voltage_5:
-      name: "${bms0} cell voltage 5"
+      name: "cell voltage 5"
       device_id: device0
     cell_voltage_6:
-      name: "${bms0} cell voltage 6"
+      name: "cell voltage 6"
       device_id: device0
     cell_voltage_7:
-      name: "${bms0} cell voltage 7"
+      name: "cell voltage 7"
       device_id: device0
     cell_voltage_8:
-      name: "${bms0} cell voltage 8"
+      name: "cell voltage 8"
       device_id: device0
     cell_voltage_9:
-      name: "${bms0} cell voltage 9"
+      name: "cell voltage 9"
       device_id: device0
     cell_voltage_10:
-      name: "${bms0} cell voltage 10"
+      name: "cell voltage 10"
       device_id: device0
     cell_voltage_11:
-      name: "${bms0} cell voltage 11"
+      name: "cell voltage 11"
       device_id: device0
     cell_voltage_12:
-      name: "${bms0} cell voltage 12"
+      name: "cell voltage 12"
       device_id: device0
     cell_voltage_13:
-      name: "${bms0} cell voltage 13"
+      name: "cell voltage 13"
       device_id: device0
     cell_voltage_14:
-      name: "${bms0} cell voltage 14"
+      name: "cell voltage 14"
       device_id: device0
     cell_voltage_15:
-      name: "${bms0} cell voltage 15"
+      name: "cell voltage 15"
       device_id: device0
     cell_voltage_16:
-      name: "${bms0} cell voltage 16"
+      name: "cell voltage 16"
       device_id: device0
     cell_voltage_17:
-      name: "${bms0} cell voltage 17"
+      name: "cell voltage 17"
       device_id: device0
     cell_voltage_18:
-      name: "${bms0} cell voltage 18"
+      name: "cell voltage 18"
       device_id: device0
     cell_voltage_19:
-      name: "${bms0} cell voltage 19"
+      name: "cell voltage 19"
       device_id: device0
     cell_voltage_20:
-      name: "${bms0} cell voltage 20"
+      name: "cell voltage 20"
       device_id: device0
     cell_voltage_21:
-      name: "${bms0} cell voltage 21"
+      name: "cell voltage 21"
       device_id: device0
     cell_voltage_22:
-      name: "${bms0} cell voltage 22"
+      name: "cell voltage 22"
       device_id: device0
     cell_voltage_23:
-      name: "${bms0} cell voltage 23"
+      name: "cell voltage 23"
       device_id: device0
     cell_voltage_24:
-      name: "${bms0} cell voltage 24"
+      name: "cell voltage 24"
       device_id: device0
     cell_voltage_25:
-      name: "${bms0} cell voltage 25"
+      name: "cell voltage 25"
       device_id: device0
     cell_voltage_26:
-      name: "${bms0} cell voltage 26"
+      name: "cell voltage 26"
       device_id: device0
     cell_voltage_27:
-      name: "${bms0} cell voltage 27"
+      name: "cell voltage 27"
       device_id: device0
     cell_voltage_28:
-      name: "${bms0} cell voltage 28"
+      name: "cell voltage 28"
       device_id: device0
     cell_voltage_29:
-      name: "${bms0} cell voltage 29"
+      name: "cell voltage 29"
       device_id: device0
     cell_voltage_30:
-      name: "${bms0} cell voltage 30"
+      name: "cell voltage 30"
       device_id: device0
     cell_voltage_31:
-      name: "${bms0} cell voltage 31"
+      name: "cell voltage 31"
       device_id: device0
     cell_voltage_32:
-      name: "${bms0} cell voltage 32"
+      name: "cell voltage 32"
       device_id: device0
     charge_mosfet_status_code:
-      name: "${bms0} charge mosfet status code"
+      name: "charge mosfet status code"
       device_id: device0
     discharge_mosfet_status_code:
-      name: "${bms0} discharge mosfet status code"
+      name: "discharge mosfet status code"
       device_id: device0
     balancer_status_code:
-      name: "${bms0} balancer status code"
+      name: "balancer status code"
       device_id: device0
 
   - platform: ant_bms
     ant_bms_id: bms1
     battery_strings:
-      name: "${bms1} battery strings"
+      name: "battery strings"
       device_id: device1
     current:
-      name: "${bms1} current"
+      name: "current"
       device_id: device1
     soc:
-      name: "${bms1} soc"
+      name: "soc"
       device_id: device1
     total_battery_capacity_setting:
-      name: "${bms1} total battery capacity setting"
+      name: "total battery capacity setting"
       device_id: device1
     capacity_remaining:
-      name: "${bms1} capacity remaining"
+      name: "capacity remaining"
       device_id: device1
     battery_cycle_capacity:
-      name: "${bms1} battery cycle capacity"
+      name: "battery cycle capacity"
       device_id: device1
     total_voltage:
-      name: "${bms1} total voltage"
+      name: "total voltage"
       device_id: device1
     total_runtime:
-      name: "${bms1} total runtime"
+      name: "total runtime"
       device_id: device1
     average_cell_voltage:
-      name: "${bms1} average cell voltage"
+      name: "average cell voltage"
       device_id: device1
     power:
-      name: "${bms1} power"
+      name: "power"
       device_id: device1
     min_cell_voltage:
-      name: "${bms1} min cell voltage"
+      name: "min cell voltage"
       device_id: device1
     max_cell_voltage:
-      name: "${bms1} max cell voltage"
+      name: "max cell voltage"
       device_id: device1
     min_voltage_cell:
-      name: "${bms1} min voltage cell"
+      name: "min voltage cell"
       device_id: device1
     max_voltage_cell:
-      name: "${bms1} max voltage cell"
+      name: "max voltage cell"
       device_id: device1
     delta_cell_voltage:
-      name: "${bms1} delta cell voltage"
+      name: "delta cell voltage"
       device_id: device1
     temperature_1:
-      name: "${bms1} temperature 1"
+      name: "temperature 1"
       device_id: device1
     temperature_2:
-      name: "${bms1} temperature 2"
+      name: "temperature 2"
       device_id: device1
     temperature_3:
-      name: "${bms1} temperature 3"
+      name: "temperature 3"
       device_id: device1
     temperature_4:
-      name: "${bms1} temperature 4"
+      name: "temperature 4"
       device_id: device1
     temperature_5:
-      name: "${bms1} temperature 5"
+      name: "temperature 5"
       device_id: device1
     temperature_6:
-      name: "${bms1} temperature 6"
+      name: "temperature 6"
       device_id: device1
     cell_voltage_1:
-      name: "${bms1} cell voltage 1"
+      name: "cell voltage 1"
       device_id: device1
     cell_voltage_2:
-      name: "${bms1} cell voltage 2"
+      name: "cell voltage 2"
       device_id: device1
     cell_voltage_3:
-      name: "${bms1} cell voltage 3"
+      name: "cell voltage 3"
       device_id: device1
     cell_voltage_4:
-      name: "${bms1} cell voltage 4"
+      name: "cell voltage 4"
       device_id: device1
     cell_voltage_5:
-      name: "${bms1} cell voltage 5"
+      name: "cell voltage 5"
       device_id: device1
     cell_voltage_6:
-      name: "${bms1} cell voltage 6"
+      name: "cell voltage 6"
       device_id: device1
     cell_voltage_7:
-      name: "${bms1} cell voltage 7"
+      name: "cell voltage 7"
       device_id: device1
     cell_voltage_8:
-      name: "${bms1} cell voltage 8"
+      name: "cell voltage 8"
       device_id: device1
     cell_voltage_9:
-      name: "${bms1} cell voltage 9"
+      name: "cell voltage 9"
       device_id: device1
     cell_voltage_10:
-      name: "${bms1} cell voltage 10"
+      name: "cell voltage 10"
       device_id: device1
     cell_voltage_11:
-      name: "${bms1} cell voltage 11"
+      name: "cell voltage 11"
       device_id: device1
     cell_voltage_12:
-      name: "${bms1} cell voltage 12"
+      name: "cell voltage 12"
       device_id: device1
     cell_voltage_13:
-      name: "${bms1} cell voltage 13"
+      name: "cell voltage 13"
       device_id: device1
     cell_voltage_14:
-      name: "${bms1} cell voltage 14"
+      name: "cell voltage 14"
       device_id: device1
     cell_voltage_15:
-      name: "${bms1} cell voltage 15"
+      name: "cell voltage 15"
       device_id: device1
     cell_voltage_16:
-      name: "${bms1} cell voltage 16"
+      name: "cell voltage 16"
       device_id: device1
     cell_voltage_17:
-      name: "${bms1} cell voltage 17"
+      name: "cell voltage 17"
       device_id: device1
     cell_voltage_18:
-      name: "${bms1} cell voltage 18"
+      name: "cell voltage 18"
       device_id: device1
     cell_voltage_19:
-      name: "${bms1} cell voltage 19"
+      name: "cell voltage 19"
       device_id: device1
     cell_voltage_20:
-      name: "${bms1} cell voltage 20"
+      name: "cell voltage 20"
       device_id: device1
     cell_voltage_21:
-      name: "${bms1} cell voltage 21"
+      name: "cell voltage 21"
       device_id: device1
     cell_voltage_22:
-      name: "${bms1} cell voltage 22"
+      name: "cell voltage 22"
       device_id: device1
     cell_voltage_23:
-      name: "${bms1} cell voltage 23"
+      name: "cell voltage 23"
       device_id: device1
     cell_voltage_24:
-      name: "${bms1} cell voltage 24"
+      name: "cell voltage 24"
       device_id: device1
     cell_voltage_25:
-      name: "${bms1} cell voltage 25"
+      name: "cell voltage 25"
       device_id: device1
     cell_voltage_26:
-      name: "${bms1} cell voltage 26"
+      name: "cell voltage 26"
       device_id: device1
     cell_voltage_27:
-      name: "${bms1} cell voltage 27"
+      name: "cell voltage 27"
       device_id: device1
     cell_voltage_28:
-      name: "${bms1} cell voltage 28"
+      name: "cell voltage 28"
       device_id: device1
     cell_voltage_29:
-      name: "${bms1} cell voltage 29"
+      name: "cell voltage 29"
       device_id: device1
     cell_voltage_30:
-      name: "${bms1} cell voltage 30"
+      name: "cell voltage 30"
       device_id: device1
     cell_voltage_31:
-      name: "${bms1} cell voltage 31"
+      name: "cell voltage 31"
       device_id: device1
     cell_voltage_32:
-      name: "${bms1} cell voltage 32"
+      name: "cell voltage 32"
       device_id: device1
     charge_mosfet_status_code:
-      name: "${bms1} charge mosfet status code"
+      name: "charge mosfet status code"
       device_id: device1
     discharge_mosfet_status_code:
-      name: "${bms1} discharge mosfet status code"
+      name: "discharge mosfet status code"
       device_id: device1
     balancer_status_code:
-      name: "${bms1} balancer status code"
+      name: "balancer status code"
       device_id: device1
 
 text_sensor:
   - platform: ant_bms
     ant_bms_id: bms0
     charge_mosfet_status:
-      name: "${bms0} charge mosfet status"
+      name: "charge mosfet status"
       device_id: device0
     discharge_mosfet_status:
-      name: "${bms0} discharge mosfet status"
+      name: "discharge mosfet status"
       device_id: device0
     balancer_status:
-      name: "${bms0} balancer status"
+      name: "balancer status"
       device_id: device0
     total_runtime_formatted:
-      name: "${bms0} total runtime formatted"
+      name: "total runtime formatted"
       device_id: device0
 
   - platform: ant_bms
     ant_bms_id: bms1
     charge_mosfet_status:
-      name: "${bms1} charge mosfet status"
+      name: "charge mosfet status"
       device_id: device1
     discharge_mosfet_status:
-      name: "${bms1} discharge mosfet status"
+      name: "discharge mosfet status"
       device_id: device1
     balancer_status:
-      name: "${bms1} balancer status"
+      name: "balancer status"
       device_id: device1
     total_runtime_formatted:
-      name: "${bms1} total runtime formatted"
+      name: "total runtime formatted"
       device_id: device1
 
 switch:
   - platform: ant_bms
     ant_bms_id: bms0
     charging:
-      name: "${bms0} charging"
+      name: "charging"
       device_id: device0
     discharging:
-      name: "${bms0} discharging"
+      name: "discharging"
       device_id: device0
     # BMS version 2021 only
     # Please enable supports_new_commands
     balancer:
-      name: "${bms0} balancer"
+      name: "balancer"
       device_id: device0
 
   - platform: ant_bms
     ant_bms_id: bms1
     charging:
-      name: "${bms1} charging"
+      name: "charging"
       device_id: device1
     discharging:
-      name: "${bms1} discharging"
+      name: "discharging"
       device_id: device1
     # BMS version 2021 only
     # Please enable supports_new_commands
     balancer:
-      name: "${bms1} balancer"
+      name: "balancer"
       device_id: device1
 
 button:
   - platform: ant_bms
     ant_bms_id: bms0
     shutdown:
-      name: "${bms0} shutdown"
+      name: "shutdown"
       device_id: device0
     clear_counter:
-      name: "${bms0} clear counter"
+      name: "clear counter"
       device_id: device0
     balancer:
-      name: "${bms0} balancer"
+      name: "balancer"
       device_id: device0
     factory_reset:
-      name: "${bms0} factory reset"
+      name: "factory reset"
       device_id: device0
     restart:
-      name: "${bms0} restart"
+      name: "restart"
       device_id: device0
 
   - platform: ant_bms
     ant_bms_id: bms1
     shutdown:
-      name: "${bms1} shutdown"
+      name: "shutdown"
       device_id: device1
     clear_counter:
-      name: "${bms1} clear counter"
+      name: "clear counter"
       device_id: device1
     balancer:
-      name: "${bms1} balancer"
+      name: "balancer"
       device_id: device1
     factory_reset:
-      name: "${bms1} factory reset"
+      name: "factory reset"
       device_id: device1
     restart:
-      name: "${bms1} restart"
+      name: "restart"
       device_id: device1


### PR DESCRIPTION
Use ESPHome sub-devices feature: entity names no longer need the device name prefix since the sub-device name is automatically prepended by Home Assistant via `has_entity_name = True` semantics.

- Remove `${bms0}`/`${bms1}` prefix from all entity `name:` fields in `*multiple-devices*.yaml`
- Add `devices:` block and `device_id:` per entity where missing (jbd-bms, tianpower-bms)