### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/ant_bms/ant_bms.cpp
+++ b/components/ant_bms/ant_bms.cpp
@@ -14,7 +14,7 @@ static const uint8_t WRITE_SINGLE_REGISTER = 0xA5;
 static const uint8_t REGISTER_APPLY_WRITE = 0xFF;
 
 static const uint8_t CHARGE_MOSFET_STATUS_SIZE = 16;
-static const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
+static constexpr const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
     "Off",                           // 0x00
     "On",                            // 0x01
     "Overcharge protection",         // 0x02
@@ -34,7 +34,7 @@ static const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
 };
 
 static const uint8_t DISCHARGE_MOSFET_STATUS_SIZE = 16;
-static const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] = {
+static constexpr const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] = {
     "Off",                           // 0x00
     "On",                            // 0x01
     "Overdischarge protection",      // 0x02
@@ -54,7 +54,7 @@ static const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] =
 };
 
 static const uint8_t BALANCER_STATUS_SIZE = 11;
-static const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
+static constexpr const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
     "Off",                                   // 0x00
     "Exceeds the limit equilibrium",         // 0x01
     "Charge differential pressure balance",  // 0x02

--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -41,7 +41,7 @@ static const uint8_t ANT_COMMAND_DEVICE_INFO = 0x02;
 static const uint8_t ANT_COMMAND_WRITE_REGISTER = 0x51;
 
 static const uint8_t CHARGE_MOSFET_STATUS_SIZE = 16;
-static const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
+static constexpr const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
     "Off",                           // 0x00
     "On",                            // 0x01
     "Overcharge protection",         // 0x02
@@ -61,7 +61,7 @@ static const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
 };
 
 static const uint8_t DISCHARGE_MOSFET_STATUS_SIZE = 16;
-static const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] = {
+static constexpr const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] = {
     "Off",                           // 0x00
     "On",                            // 0x01
     "Overdischarge protection",      // 0x02
@@ -81,7 +81,7 @@ static const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] =
 };
 
 static const uint8_t BALANCER_STATUS_SIZE = 11;
-static const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
+static constexpr const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
     "Off",                                   // 0x00
     "Exceeds the limit equilibrium",         // 0x01
     "Charge differential pressure balance",  // 0x02

--- a/components/ant_bms_old/ant_bms_old.cpp
+++ b/components/ant_bms_old/ant_bms_old.cpp
@@ -20,7 +20,7 @@ static const uint8_t WRITE_SINGLE_REGISTER = 0xA5;
 static const uint8_t REGISTER_APPLY_WRITE = 0xFF;
 
 static const uint8_t CHARGE_MOSFET_STATUS_SIZE = 16;
-static const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
+static constexpr const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
     "Off",                           // 0x00
     "On",                            // 0x01
     "Overcharge protection",         // 0x02
@@ -40,7 +40,7 @@ static const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
 };
 
 static const uint8_t DISCHARGE_MOSFET_STATUS_SIZE = 16;
-static const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] = {
+static constexpr const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] = {
     "Off",                           // 0x00
     "On",                            // 0x01
     "Overdischarge protection",      // 0x02
@@ -60,7 +60,7 @@ static const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] =
 };
 
 static const uint8_t BALANCER_STATUS_SIZE = 11;
-static const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
+static constexpr const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
     "Off",                                   // 0x00
     "Exceeds the limit equilibrium",         // 0x01
     "Charge differential pressure balance",  // 0x02

--- a/components/ant_bms_old_ble/ant_bms_old_ble.cpp
+++ b/components/ant_bms_old_ble/ant_bms_old_ble.cpp
@@ -29,7 +29,7 @@ static const uint8_t WRITE_SINGLE_REGISTER = 0xA5;
 static const uint8_t REGISTER_APPLY_WRITE = 0xFF;
 
 static const uint8_t CHARGE_MOSFET_STATUS_SIZE = 16;
-static const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
+static constexpr const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
     "Off",                           // 0x00
     "On",                            // 0x01
     "Overcharge protection",         // 0x02
@@ -49,7 +49,7 @@ static const char *const CHARGE_MOSFET_STATUS[CHARGE_MOSFET_STATUS_SIZE] = {
 };
 
 static const uint8_t DISCHARGE_MOSFET_STATUS_SIZE = 16;
-static const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] = {
+static constexpr const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] = {
     "Off",                           // 0x00
     "On",                            // 0x01
     "Overdischarge protection",      // 0x02
@@ -69,7 +69,7 @@ static const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STATUS_SIZE] =
 };
 
 static const uint8_t BALANCER_STATUS_SIZE = 11;
-static const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
+static constexpr const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
     "Off",                                   // 0x00
     "Exceeds the limit equilibrium",         // 0x01
     "Charge differential pressure balance",  // 0x02


### PR DESCRIPTION
## Summary

- Replaces `static const char *const` array declarations with `static constexpr const char *const` in all four affected components (`ant_bms`, `ant_bms_old`, `ant_bms_ble`, `ant_bms_old_ble`).
- With `constexpr`, the compiler guarantees these string arrays are evaluated at compile time and placed in the read-only segment (Flash), so they do not consume RAM at runtime.
- This matches the style used in ESPHome core (e.g. `bme68x_bsec2.cpp`) and is the recommended approach for constant string tables on embedded targets.

## Affected files

- `components/ant_bms/ant_bms.cpp` (lines 17, 37, 57)
- `components/ant_bms_old/ant_bms_old.cpp` (lines 23, 43, 63)
- `components/ant_bms_ble/ant_bms_ble.cpp` (lines 44, 64, 84)
- `components/ant_bms_old_ble/ant_bms_old_ble.cpp` (lines 32, 52, 72)