### PR TITLE
Add entity_category to all text sensor schemas

### DIFF
--- a/components/ant_bms/text_sensor.py
+++ b/components/ant_bms/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_TIMELAPSE
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_TIMELAPSE
 
 from . import ANT_BMS_COMPONENT_SCHEMA, CONF_ANT_BMS_ID
 
@@ -28,16 +28,20 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ANT_BMS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_CHARGE_MOSFET_STATUS
+            icon=ICON_CHARGE_MOSFET_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_DISCHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_DISCHARGE_MOSFET_STATUS
+            icon=ICON_DISCHARGE_MOSFET_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_BALANCER_STATUS
+            icon=ICON_BALANCER_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )

--- a/components/ant_bms_old/text_sensor.py
+++ b/components/ant_bms_old/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_TIMELAPSE
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_TIMELAPSE
 
 from . import ANT_BMS_OLD_COMPONENT_SCHEMA, CONF_ANT_BMS_OLD_ID
 
@@ -28,16 +28,20 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ANT_BMS_OLD_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_CHARGE_MOSFET_STATUS
+            icon=ICON_CHARGE_MOSFET_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_DISCHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_DISCHARGE_MOSFET_STATUS
+            icon=ICON_DISCHARGE_MOSFET_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_BALANCER_STATUS
+            icon=ICON_BALANCER_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )

--- a/components/ant_bms_old_ble/text_sensor.py
+++ b/components/ant_bms_old_ble/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_TIMELAPSE
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_TIMELAPSE
 
 from . import ANT_BMS_OLD_BLE_COMPONENT_SCHEMA, CONF_ANT_BMS_OLD_BLE_ID
 
@@ -28,16 +28,20 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = ANT_BMS_OLD_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_CHARGE_MOSFET_STATUS
+            icon=ICON_CHARGE_MOSFET_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_DISCHARGE_MOSFET_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_DISCHARGE_MOSFET_STATUS
+            icon=ICON_DISCHARGE_MOSFET_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
-            icon=ICON_BALANCER_STATUS
+            icon=ICON_BALANCER_STATUS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
-            icon=ICON_TIMELAPSE
+            icon=ICON_TIMELAPSE,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )


### PR DESCRIPTION
Text sensors were missing `entity_category=ENTITY_CATEGORY_DIAGNOSTIC`, which causes them to appear as regular state entities instead of diagnostic ones in Home Assistant.