### PR TITLE
Use C++17 concatenated namespace syntax, update .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/ant_bms/ant_bms.cpp
+++ b/components/ant_bms/ant_bms.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace ant_bms {
+namespace esphome::ant_bms {
 
 static const char *const TAG = "ant_bms";
 
@@ -567,5 +566,4 @@ void AntBms::send_v2021_(uint8_t function, uint8_t address, uint16_t value) {
   this->flush();
 }
 
-}  // namespace ant_bms
-}  // namespace esphome
+}  // namespace esphome::ant_bms

--- a/components/ant_bms/ant_bms.h
+++ b/components/ant_bms/ant_bms.h
@@ -7,8 +7,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace ant_bms {
+namespace esphome::ant_bms {
 
 class AntBms : public uart::UARTDevice, public PollingComponent {
  public:
@@ -210,5 +209,4 @@ class AntBms : public uart::UARTDevice, public PollingComponent {
   }
 };
 
-}  // namespace ant_bms
-}  // namespace esphome
+}  // namespace esphome::ant_bms

--- a/components/ant_bms/button/ant_button.cpp
+++ b/components/ant_bms/button/ant_button.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ant_bms {
+namespace esphome::ant_bms {
 
 static const char *const TAG = "ant_bms.button";
 
 void AntButton::dump_config() { LOG_BUTTON("", "AntBms Button", this); }
 void AntButton::press_action() { this->parent_->write_register(this->holding_register_, 0x0000); }
 
-}  // namespace ant_bms
-}  // namespace esphome
+}  // namespace esphome::ant_bms

--- a/components/ant_bms/button/ant_button.h
+++ b/components/ant_bms/button/ant_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace ant_bms {
+namespace esphome::ant_bms {
 
 class AntBms;
 class AntButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class AntButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace ant_bms
-}  // namespace esphome
+}  // namespace esphome::ant_bms

--- a/components/ant_bms/switch/ant_switch.cpp
+++ b/components/ant_bms/switch/ant_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ant_bms {
+namespace esphome::ant_bms {
 
 static const char *const TAG = "ant_bms.switch";
 
@@ -23,5 +22,4 @@ void AntSwitch::write_state(bool state) {
   this->parent_->write_register(this->holding_register_, (uint16_t) state);
 }
 
-}  // namespace ant_bms
-}  // namespace esphome
+}  // namespace esphome::ant_bms

--- a/components/ant_bms/switch/ant_switch.h
+++ b/components/ant_bms/switch/ant_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace ant_bms {
+namespace esphome::ant_bms {
 
 class AntBms;
 class AntSwitch : public switch_::Switch, public Component {
@@ -31,5 +30,4 @@ class AntSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
 };
 
-}  // namespace ant_bms
-}  // namespace esphome
+}  // namespace esphome::ant_bms

--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace ant_bms_ble {
+namespace esphome::ant_bms_ble {
 
 static const char *const TAG = "ant_bms_ble";
 
@@ -706,5 +705,4 @@ bool AntBmsBle::send_(uint8_t function, uint16_t address, uint8_t value, bool au
   return (status == 0);
 }
 
-}  // namespace ant_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_ble

--- a/components/ant_bms_ble/ant_bms_ble.h
+++ b/components/ant_bms_ble/ant_bms_ble.h
@@ -12,8 +12,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace ant_bms_ble {
+namespace esphome::ant_bms_ble {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -211,7 +210,6 @@ class AntBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
   }
 };
 
-}  // namespace ant_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_ble
 
 #endif

--- a/components/ant_bms_ble/button/ant_button.cpp
+++ b/components/ant_bms_ble/button/ant_button.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ant_bms_ble {
+namespace esphome::ant_bms_ble {
 
 static const char *const TAG = "ant_bms_ble.button";
 
 void AntButton::dump_config() { LOG_BUTTON("", "AntBmsBle Button", this); }
 void AntButton::press_action() { this->parent_->write_register(this->holding_register_, 0x00); }
 
-}  // namespace ant_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_ble

--- a/components/ant_bms_ble/button/ant_button.h
+++ b/components/ant_bms_ble/button/ant_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace ant_bms_ble {
+namespace esphome::ant_bms_ble {
 
 class AntBmsBle;
 class AntButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class AntButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace ant_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_ble

--- a/components/ant_bms_ble/switch/ant_switch.cpp
+++ b/components/ant_bms_ble/switch/ant_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ant_bms_ble {
+namespace esphome::ant_bms_ble {
 
 static const char *const TAG = "ant_bms_ble.switch";
 
@@ -12,5 +11,4 @@ void AntSwitch::write_state(bool state) {
   this->parent_->write_register((state) ? this->turn_on_register_ : this->turn_off_register_, 0x00);
 }
 
-}  // namespace ant_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_ble

--- a/components/ant_bms_ble/switch/ant_switch.h
+++ b/components/ant_bms_ble/switch/ant_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace ant_bms_ble {
+namespace esphome::ant_bms_ble {
 
 class AntBmsBle;
 class AntSwitch : public switch_::Switch, public Component {
@@ -25,5 +24,4 @@ class AntSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
 };
 
-}  // namespace ant_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_ble

--- a/components/ant_bms_old/ant_bms_old.cpp
+++ b/components/ant_bms_old/ant_bms_old.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace ant_bms_old {
+namespace esphome::ant_bms_old {
 
 static const char *const TAG = "ant_bms_old";
 
@@ -471,5 +470,4 @@ void AntBmsOld::send_(uint8_t function, uint8_t address, uint16_t value) {
 
 void AntBmsOld::read_registers_() { this->send_(0x5A, 0x00, 0x0001); }
 
-}  // namespace ant_bms_old
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old

--- a/components/ant_bms_old/ant_bms_old.h
+++ b/components/ant_bms_old/ant_bms_old.h
@@ -7,8 +7,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace ant_bms_old {
+namespace esphome::ant_bms_old {
 
 class AntBmsOld : public uart::UARTDevice, public PollingComponent {
  public:
@@ -188,5 +187,4 @@ class AntBmsOld : public uart::UARTDevice, public PollingComponent {
   }
 };
 
-}  // namespace ant_bms_old
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old

--- a/components/ant_bms_old/button/ant_button.cpp
+++ b/components/ant_bms_old/button/ant_button.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ant_bms_old {
+namespace esphome::ant_bms_old {
 
 static const char *const TAG = "ant_bms_old.button";
 
 void AntButton::dump_config() { LOG_BUTTON("", "AntBmsOld Button", this); }
 void AntButton::press_action() { this->parent_->write_register(this->holding_register_, 0x0000); }
 
-}  // namespace ant_bms_old
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old

--- a/components/ant_bms_old/button/ant_button.h
+++ b/components/ant_bms_old/button/ant_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace ant_bms_old {
+namespace esphome::ant_bms_old {
 
 class AntBmsOld;
 class AntButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class AntButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace ant_bms_old
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old

--- a/components/ant_bms_old/switch/ant_switch.cpp
+++ b/components/ant_bms_old/switch/ant_switch.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ant_bms_old {
+namespace esphome::ant_bms_old {
 
 static const char *const TAG = "ant_bms_old.switch";
 
 void AntSwitch::dump_config() { LOG_SWITCH("", "AntBmsOld Switch", this); }
 void AntSwitch::write_state(bool state) { this->parent_->write_register(this->holding_register_, (uint16_t) state); }
 
-}  // namespace ant_bms_old
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old

--- a/components/ant_bms_old/switch/ant_switch.h
+++ b/components/ant_bms_old/switch/ant_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace ant_bms_old {
+namespace esphome::ant_bms_old {
 
 class AntBmsOld;
 class AntSwitch : public switch_::Switch, public Component {
@@ -23,5 +22,4 @@ class AntSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
 };
 
-}  // namespace ant_bms_old
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old

--- a/components/ant_bms_old_ble/ant_bms_old_ble.cpp
+++ b/components/ant_bms_old_ble/ant_bms_old_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace ant_bms_old_ble {
+namespace esphome::ant_bms_old_ble {
 
 static const char *const TAG = "ant_bms_old_ble";
 
@@ -517,5 +516,4 @@ bool AntBmsOldBle::send_(uint8_t function, uint8_t address, uint16_t value) {
 
 bool AntBmsOldBle::read_registers_() { return this->send_(0xDB, 0x00, 0x0000); }
 
-}  // namespace ant_bms_old_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old_ble

--- a/components/ant_bms_old_ble/ant_bms_old_ble.h
+++ b/components/ant_bms_old_ble/ant_bms_old_ble.h
@@ -12,8 +12,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace ant_bms_old_ble {
+namespace esphome::ant_bms_old_ble {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -191,7 +190,6 @@ class AntBmsOldBle : public esphome::ble_client::BLEClientNode, public PollingCo
   }
 };
 
-}  // namespace ant_bms_old_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old_ble
 
 #endif

--- a/components/ant_bms_old_ble/button/ant_button.cpp
+++ b/components/ant_bms_old_ble/button/ant_button.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ant_bms_old_ble {
+namespace esphome::ant_bms_old_ble {
 
 static const char *const TAG = "ant_bms_old_ble.button";
 
 void AntButton::dump_config() { LOG_BUTTON("", "AntBmsOldBle Button", this); }
 void AntButton::press_action() { this->parent_->write_register(this->holding_register_, 0x00); }
 
-}  // namespace ant_bms_old_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old_ble

--- a/components/ant_bms_old_ble/button/ant_button.h
+++ b/components/ant_bms_old_ble/button/ant_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace ant_bms_old_ble {
+namespace esphome::ant_bms_old_ble {
 
 class AntBmsOldBle;
 class AntButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class AntButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace ant_bms_old_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old_ble

--- a/components/ant_bms_old_ble/switch/ant_switch.cpp
+++ b/components/ant_bms_old_ble/switch/ant_switch.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ant_bms_old_ble {
+namespace esphome::ant_bms_old_ble {
 
 static const char *const TAG = "ant_bms_old_ble.switch";
 
 void AntSwitch::dump_config() { LOG_SWITCH("", "AntBmsOldBle Switch", this); }
 void AntSwitch::write_state(bool state) { this->parent_->write_register(this->holding_register_, (uint16_t) state); }
 
-}  // namespace ant_bms_old_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old_ble

--- a/components/ant_bms_old_ble/switch/ant_switch.h
+++ b/components/ant_bms_old_ble/switch/ant_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace ant_bms_old_ble {
+namespace esphome::ant_bms_old_ble {
 
 class AntBmsOldBle;
 class AntSwitch : public switch_::Switch, public Component {
@@ -23,5 +22,4 @@ class AntSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
 };
 
-}  // namespace ant_bms_old_ble
-}  // namespace esphome
+}  // namespace esphome::ant_bms_old_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.