### PR TITLE
Introduce new sensors to expose additional states of the new status frame

### DIFF
--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -79,6 +79,16 @@ static constexpr const char *const DISCHARGE_MOSFET_STATUS[DISCHARGE_MOSFET_STAT
     "Manually turned off",           // 0x0F
 };
 
+static const uint8_t BATTERY_STATUS_SIZE = 6;
+static constexpr const char *const BATTERY_STATUS[BATTERY_STATUS_SIZE] = {
+    "Unknown",    // 0x00
+    "Idle",       // 0x01
+    "Charge",     // 0x02
+    "Discharge",  // 0x03
+    "Standby",    // 0x04
+    "Error",      // 0x05
+};
+
 static const uint8_t BALANCER_STATUS_SIZE = 11;
 static constexpr const char *const BALANCER_STATUS[BALANCER_STATUS_SIZE] = {
     "Off",                                   // 0x00
@@ -277,7 +287,13 @@ void AntBmsBle::on_status_data_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "  Permissions: %d", data[6]);
 
   //   7   1  0x01        Battery status (0: Unknown, 1: Idle, 2: Charge, 3: Discharge, 4: Standby, 5: Error)
-  ESP_LOGI(TAG, "  Battery status: %d", data[7]);
+  uint8_t raw_battery_status = data[7];
+  this->publish_state_(this->battery_status_code_sensor_, (float) raw_battery_status);
+  if (raw_battery_status < BATTERY_STATUS_SIZE) {
+    this->publish_state_(this->battery_status_text_sensor_, BATTERY_STATUS[raw_battery_status]);
+  } else {
+    this->publish_state_(this->battery_status_text_sensor_, "Unknown");
+  }
 
   //   8   1  0x04        Number of temperature sensors       max 4.
   uint8_t temperature_sensors = data[8];
@@ -342,7 +358,7 @@ void AntBmsBle::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->soc_sensor_, ((int16_t) ant_get_16bit(42 + offset)) * 1.0f);
 
   //  80   2  0x64 0x00   State of health            uint16_t
-  ESP_LOGI(TAG, "  State of health: %.0f %%", ant_get_16bit(44 + offset) * 1.0f);
+  this->publish_state_(this->state_of_health_sensor_, ant_get_16bit(44 + offset) * 1.0f);
 
   //  82   1  0x01        Charge MOS status
   uint8_t raw_charge_mosfet_status = data[46 + offset];
@@ -389,14 +405,12 @@ void AntBmsBle::on_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->power_sensor_, ((int32_t) ant_get_32bit(62 + offset)) * 1.0f);
 
   // 102   4  0x6B 0x28 0x12 0x00    Total runtime
-  this->publish_state_(this->total_runtime_sensor_, (float) ant_get_32bit(66 + offset));
-
-  if (this->total_runtime_formatted_text_sensor_ != nullptr) {
-    this->publish_state_(this->total_runtime_formatted_text_sensor_, format_total_runtime_(ant_get_32bit(66 + offset)));
-  }
+  uint32_t raw_total_runtime = ant_get_32bit(66 + offset);
+  this->publish_state_(this->total_runtime_sensor_, (float) raw_total_runtime);
+  this->publish_state_(this->total_runtime_formatted_text_sensor_, format_total_runtime_(raw_total_runtime));
 
   // 106   4  0x00 0x00 0x00 0x00    Balanced cell bitmask
-  ESP_LOGI(TAG, "  Balanced cell bitmask: %lu", (unsigned long) ant_get_32bit(70 + offset));
+  this->publish_state_(this->balanced_cell_bitmask_sensor_, (float) ant_get_32bit(70 + offset));
 
   // 110   2  0x11 0x10              Maximum cell voltage
   this->publish_state_(this->max_cell_voltage_sensor_, ant_get_16bit(74 + offset) * 0.001f);
@@ -422,17 +436,23 @@ void AntBmsBle::on_status_data_(const std::vector<uint8_t> &data) {
   // 128   2  0xAC 0x02              F40com
   // 130   2  0xF1 0xFA              Battery type (0xfaf1: Ternary Lithium, 0xfaf2: Lithium Iron Phosphate,
   //                                               0xfaf3: Lithium Titanate, 0xfaf4: Custom)
-  // 132   4  0x7D 0x2E 0x00 0x00    Accumulated discharging capacity
-  ESP_LOGI(TAG, "  Accumulated discharging capacity: %.2f Ah", ant_get_32bit(96 + offset) * 0.001f);
+  // 132   4  0x7D 0x2E 0x00 0x00    Total discharging capacity
+  this->publish_state_(this->total_discharging_capacity_sensor_, ant_get_32bit(96 + offset) * 0.001f);
 
-  // 136   4  0x94 0x77 0x00 0x00    Accumulated charging capacity
-  ESP_LOGI(TAG, "  Accumulated charging capacity: %.2f Ah", ant_get_32bit(100 + offset) * 0.001f);
+  // 136   4  0x94 0x77 0x00 0x00    Total charging capacity
+  this->publish_state_(this->total_charging_capacity_sensor_, ant_get_32bit(100 + offset) * 0.001f);
 
-  // 140   4  0xDE 0x07 0x00 0x00    Accumulated discharging time
-  ESP_LOGI(TAG, "  Accumulated discharging time: %s", this->format_total_runtime_(ant_get_32bit(104 + offset)).c_str());
+  // 140   4  0xDE 0x07 0x00 0x00    Total discharging time
+  uint32_t raw_total_discharging_time = ant_get_32bit(104 + offset);
+  this->publish_state_(this->total_discharging_time_sensor_, (float) raw_total_discharging_time);
+  this->publish_state_(this->total_discharging_time_formatted_text_sensor_,
+                       format_total_runtime_(raw_total_discharging_time));
 
-  // 144   4  0x77 0x76 0x00 0x00    Accumulated charging time
-  ESP_LOGI(TAG, "  Accumulated charging time: %s", this->format_total_runtime_(ant_get_32bit(108 + offset)).c_str());
+  // 144   4  0x77 0x76 0x00 0x00    Total charging time
+  uint32_t raw_total_charging_time = ant_get_32bit(108 + offset);
+  this->publish_state_(this->total_charging_time_sensor_, (float) raw_total_charging_time);
+  this->publish_state_(this->total_charging_time_formatted_text_sensor_,
+                       format_total_runtime_(raw_total_charging_time));
 
   // 148   2  0x35 0xE2              CRC
   // 150   2  0xAA 0x55              End of frame
@@ -493,6 +513,9 @@ void AntBmsBle::publish_device_unavailable_() {
   this->publish_state_(this->charge_mosfet_status_text_sensor_, "Offline");
   this->publish_state_(this->balancer_status_text_sensor_, "Offline");
   this->publish_state_(this->total_runtime_formatted_text_sensor_, "Offline");
+  this->publish_state_(this->battery_status_text_sensor_, "Offline");
+  this->publish_state_(this->total_discharging_time_formatted_text_sensor_, "Offline");
+  this->publish_state_(this->total_charging_time_formatted_text_sensor_, "Offline");
 
   this->publish_state_(battery_strings_sensor_, NAN);
   this->publish_state_(current_sensor_, NAN);
@@ -511,6 +534,13 @@ void AntBmsBle::publish_device_unavailable_() {
   this->publish_state_(charge_mosfet_status_code_sensor_, NAN);
   this->publish_state_(discharge_mosfet_status_code_sensor_, NAN);
   this->publish_state_(balancer_status_code_sensor_, NAN);
+  this->publish_state_(state_of_health_sensor_, NAN);
+  this->publish_state_(battery_status_code_sensor_, NAN);
+  this->publish_state_(total_discharging_capacity_sensor_, NAN);
+  this->publish_state_(total_charging_capacity_sensor_, NAN);
+  this->publish_state_(total_discharging_time_sensor_, NAN);
+  this->publish_state_(total_charging_time_sensor_, NAN);
+  this->publish_state_(balanced_cell_bitmask_sensor_, NAN);
 
   for (auto &temperature : this->temperatures_) {
     this->publish_state_(temperature.temperature_sensor_, NAN);
@@ -580,11 +610,21 @@ void AntBmsBle::dump_config() {  // NOLINT(google-readability-function-size,read
   LOG_SENSOR("", "Charge Mosfet Status Code", this->charge_mosfet_status_code_sensor_);
   LOG_SENSOR("", "Discharge Mosfet Status Code", this->discharge_mosfet_status_code_sensor_);
   LOG_SENSOR("", "Balancer Status Code", this->balancer_status_code_sensor_);
+  LOG_SENSOR("", "State Of Health", this->state_of_health_sensor_);
+  LOG_SENSOR("", "Battery Status Code", this->battery_status_code_sensor_);
+  LOG_SENSOR("", "Total Discharging Capacity", this->total_discharging_capacity_sensor_);
+  LOG_SENSOR("", "Total Charging Capacity", this->total_charging_capacity_sensor_);
+  LOG_SENSOR("", "Total Discharging Time", this->total_discharging_time_sensor_);
+  LOG_SENSOR("", "Total Charging Time", this->total_charging_time_sensor_);
+  LOG_SENSOR("", "Balanced Cell Bitmask", this->balanced_cell_bitmask_sensor_);
 
   LOG_TEXT_SENSOR("", "Discharge Mosfet Status", this->discharge_mosfet_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Charge Mosfet Status", this->charge_mosfet_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Balancer Status", this->balancer_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Total Runtime Formatted", this->total_runtime_formatted_text_sensor_);
+  LOG_TEXT_SENSOR("", "Battery Status", this->battery_status_text_sensor_);
+  LOG_TEXT_SENSOR("", "Total Discharging Time Formatted", this->total_discharging_time_formatted_text_sensor_);
+  LOG_TEXT_SENSOR("", "Total Charging Time Formatted", this->total_charging_time_formatted_text_sensor_);
   LOG_TEXT_SENSOR("", "Device Model", this->device_model_text_sensor_);
   LOG_TEXT_SENSOR("", "Software Version", this->software_version_text_sensor_);
 }

--- a/components/ant_bms_ble/ant_bms_ble.h
+++ b/components/ant_bms_ble/ant_bms_ble.h
@@ -84,6 +84,27 @@ class AntBmsBle :
   void set_balancer_status_code_sensor(sensor::Sensor *balancer_status_code_sensor) {
     balancer_status_code_sensor_ = balancer_status_code_sensor;
   }
+  void set_state_of_health_sensor(sensor::Sensor *state_of_health_sensor) {
+    state_of_health_sensor_ = state_of_health_sensor;
+  }
+  void set_battery_status_code_sensor(sensor::Sensor *battery_status_code_sensor) {
+    battery_status_code_sensor_ = battery_status_code_sensor;
+  }
+  void set_total_discharging_capacity_sensor(sensor::Sensor *total_discharging_capacity_sensor) {
+    total_discharging_capacity_sensor_ = total_discharging_capacity_sensor;
+  }
+  void set_total_charging_capacity_sensor(sensor::Sensor *total_charging_capacity_sensor) {
+    total_charging_capacity_sensor_ = total_charging_capacity_sensor;
+  }
+  void set_total_discharging_time_sensor(sensor::Sensor *total_discharging_time_sensor) {
+    total_discharging_time_sensor_ = total_discharging_time_sensor;
+  }
+  void set_total_charging_time_sensor(sensor::Sensor *total_charging_time_sensor) {
+    total_charging_time_sensor_ = total_charging_time_sensor;
+  }
+  void set_balanced_cell_bitmask_sensor(sensor::Sensor *balanced_cell_bitmask_sensor) {
+    balanced_cell_bitmask_sensor_ = balanced_cell_bitmask_sensor;
+  }
 
   void set_device_model_text_sensor(text_sensor::TextSensor *device_model_text_sensor) {
     device_model_text_sensor_ = device_model_text_sensor;
@@ -102,6 +123,17 @@ class AntBmsBle :
   }
   void set_total_runtime_formatted_text_sensor(text_sensor::TextSensor *total_runtime_formatted_text_sensor) {
     total_runtime_formatted_text_sensor_ = total_runtime_formatted_text_sensor;
+  }
+  void set_battery_status_text_sensor(text_sensor::TextSensor *battery_status_text_sensor) {
+    battery_status_text_sensor_ = battery_status_text_sensor;
+  }
+  void set_total_discharging_time_formatted_text_sensor(
+      text_sensor::TextSensor *total_discharging_time_formatted_text_sensor) {
+    total_discharging_time_formatted_text_sensor_ = total_discharging_time_formatted_text_sensor;
+  }
+  void set_total_charging_time_formatted_text_sensor(
+      text_sensor::TextSensor *total_charging_time_formatted_text_sensor) {
+    total_charging_time_formatted_text_sensor_ = total_charging_time_formatted_text_sensor;
   }
 
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
@@ -136,6 +168,13 @@ class AntBmsBle :
   sensor::Sensor *charge_mosfet_status_code_sensor_{nullptr};
   sensor::Sensor *discharge_mosfet_status_code_sensor_{nullptr};
   sensor::Sensor *balancer_status_code_sensor_{nullptr};
+  sensor::Sensor *state_of_health_sensor_{nullptr};
+  sensor::Sensor *battery_status_code_sensor_{nullptr};
+  sensor::Sensor *total_discharging_capacity_sensor_{nullptr};
+  sensor::Sensor *total_charging_capacity_sensor_{nullptr};
+  sensor::Sensor *total_discharging_time_sensor_{nullptr};
+  sensor::Sensor *total_charging_time_sensor_{nullptr};
+  sensor::Sensor *balanced_cell_bitmask_sensor_{nullptr};
 
   switch_::Switch *charging_switch_{nullptr};
   switch_::Switch *discharging_switch_{nullptr};
@@ -147,6 +186,9 @@ class AntBmsBle :
   text_sensor::TextSensor *discharge_mosfet_status_text_sensor_{nullptr};
   text_sensor::TextSensor *balancer_status_text_sensor_{nullptr};
   text_sensor::TextSensor *total_runtime_formatted_text_sensor_{nullptr};
+  text_sensor::TextSensor *battery_status_text_sensor_{nullptr};
+  text_sensor::TextSensor *total_discharging_time_formatted_text_sensor_{nullptr};
+  text_sensor::TextSensor *total_charging_time_formatted_text_sensor_{nullptr};
   text_sensor::TextSensor *device_model_text_sensor_{nullptr};
   text_sensor::TextSensor *software_version_text_sensor_{nullptr};
 

--- a/components/ant_bms_ble/sensor.py
+++ b/components/ant_bms_ble/sensor.py
@@ -46,6 +46,13 @@ CONF_DELTA_CELL_VOLTAGE = "delta_cell_voltage"
 CONF_CHARGE_MOSFET_STATUS_CODE = "charge_mosfet_status_code"
 CONF_DISCHARGE_MOSFET_STATUS_CODE = "discharge_mosfet_status_code"
 CONF_BALANCER_STATUS_CODE = "balancer_status_code"
+CONF_STATE_OF_HEALTH = "state_of_health"
+CONF_BATTERY_STATUS_CODE = "battery_status_code"
+CONF_TOTAL_DISCHARGING_CAPACITY = "total_discharging_capacity"
+CONF_TOTAL_CHARGING_CAPACITY = "total_charging_capacity"
+CONF_TOTAL_DISCHARGING_TIME = "total_discharging_time"
+CONF_TOTAL_CHARGING_TIME = "total_charging_time"
+CONF_BALANCED_CELL_BITMASK = "balanced_cell_bitmask"
 
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_BATTERY_STRINGS = "mdi:car-battery"
@@ -55,6 +62,14 @@ ICON_BATTERY_CYCLE_CAPACITY = "mdi:battery-50"
 ICON_CHARGE_MOSFET_STATUS_CODE = "mdi:heart-pulse"
 ICON_DISCHARGE_MOSFET_STATUS_CODE = "mdi:heart-pulse"
 ICON_BALANCER_STATUS_CODE = "mdi:heart-pulse"
+
+ICON_STATE_OF_HEALTH = "mdi:battery-heart"
+ICON_BATTERY_STATUS_CODE = "mdi:heart-pulse"
+ICON_TOTAL_DISCHARGING_CAPACITY = "mdi:battery-minus"
+ICON_TOTAL_CHARGING_CAPACITY = "mdi:battery-plus"
+ICON_TOTAL_DISCHARGING_TIME = "mdi:timer-outline"
+ICON_TOTAL_CHARGING_TIME = "mdi:timer-outline"
+ICON_BALANCED_CELL_BITMASK = "mdi:battery-sync"
 
 ICON_MIN_CELL_VOLTAGE = "mdi:battery-minus-outline"
 ICON_MAX_CELL_VOLTAGE = "mdi:battery-plus-outline"
@@ -190,6 +205,55 @@ SENSOR_DEFS = {
     CONF_BALANCER_STATUS_CODE: {
         "unit_of_measurement": UNIT_EMPTY,
         "icon": ICON_BALANCER_STATUS_CODE,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_STATE_OF_HEALTH: {
+        "unit_of_measurement": UNIT_PERCENT,
+        "icon": ICON_STATE_OF_HEALTH,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BATTERY_STATUS_CODE: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_BATTERY_STATUS_CODE,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_TOTAL_DISCHARGING_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_TOTAL_DISCHARGING_CAPACITY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TOTAL_CHARGING_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_TOTAL_CHARGING_CAPACITY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TOTAL_DISCHARGING_TIME: {
+        "unit_of_measurement": UNIT_SECONDS,
+        "icon": ICON_TOTAL_DISCHARGING_TIME,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TOTAL_CHARGING_TIME: {
+        "unit_of_measurement": UNIT_SECONDS,
+        "icon": ICON_TOTAL_CHARGING_TIME,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_BALANCED_CELL_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_BALANCED_CELL_BITMASK,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,
         "state_class": STATE_CLASS_MEASUREMENT,

--- a/components/ant_bms_ble/text_sensor.py
+++ b/components/ant_bms_ble/text_sensor.py
@@ -12,13 +12,17 @@ CODEOWNERS = ["@syssi"]
 CONF_CHARGE_MOSFET_STATUS = "charge_mosfet_status"
 CONF_DISCHARGE_MOSFET_STATUS = "discharge_mosfet_status"
 CONF_BALANCER_STATUS = "balancer_status"
+CONF_BATTERY_STATUS = "battery_status"
 CONF_DEVICE_MODEL = "device_model"
 CONF_SOFTWARE_VERSION = "software_version"
 CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
+CONF_TOTAL_DISCHARGING_TIME_FORMATTED = "total_discharging_time_formatted"
+CONF_TOTAL_CHARGING_TIME_FORMATTED = "total_charging_time_formatted"
 
 ICON_CHARGE_MOSFET_STATUS = "mdi:heart-pulse"
 ICON_DISCHARGE_MOSFET_STATUS = "mdi:heart-pulse"
 ICON_BALANCER_STATUS = "mdi:heart-pulse"
+ICON_BATTERY_STATUS = "mdi:heart-pulse"
 ICON_DEVICE_MODEL = "mdi:identifier"
 ICON_SOFTWARE_VERSION = "mdi:chip"
 # ICON_TOTAL_RUNTIME_FORMATTED = ICON_TIMELAPSE
@@ -27,9 +31,12 @@ TEXT_SENSORS = [
     CONF_CHARGE_MOSFET_STATUS,
     CONF_DISCHARGE_MOSFET_STATUS,
     CONF_BALANCER_STATUS,
+    CONF_BATTERY_STATUS,
     CONF_DEVICE_MODEL,
     CONF_SOFTWARE_VERSION,
     CONF_TOTAL_RUNTIME_FORMATTED,
+    CONF_TOTAL_DISCHARGING_TIME_FORMATTED,
+    CONF_TOTAL_CHARGING_TIME_FORMATTED,
 ]
 
 CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
@@ -43,6 +50,9 @@ CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_BALANCER_STATUS): text_sensor.text_sensor_schema(
             icon=ICON_BALANCER_STATUS
         ),
+        cv.Optional(CONF_BATTERY_STATUS): text_sensor.text_sensor_schema(
+            icon=ICON_BATTERY_STATUS
+        ),
         cv.Optional(CONF_DEVICE_MODEL): text_sensor.text_sensor_schema(
             icon=ICON_DEVICE_MODEL,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -52,6 +62,12 @@ CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
+            icon=ICON_TIMELAPSE
+        ),
+        cv.Optional(
+            CONF_TOTAL_DISCHARGING_TIME_FORMATTED
+        ): text_sensor.text_sensor_schema(icon=ICON_TIMELAPSE),
+        cv.Optional(CONF_TOTAL_CHARGING_TIME_FORMATTED): text_sensor.text_sensor_schema(
             icon=ICON_TIMELAPSE
         ),
     }

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -179,6 +179,20 @@ sensor:
       name: "discharge mosfet status code"
     balancer_status_code:
       name: "balancer status code"
+    state_of_health:
+      name: "state of health"
+    battery_status_code:
+      name: "battery status code"
+    total_discharging_capacity:
+      name: "accumulated discharging capacity"
+    total_charging_capacity:
+      name: "accumulated charging capacity"
+    total_discharging_time:
+      name: "accumulated discharging time"
+    total_charging_time:
+      name: "accumulated charging time"
+    balanced_cell_bitmask:
+      name: "balanced cell bitmask"
 
 text_sensor:
   - platform: ant_bms_ble
@@ -191,6 +205,12 @@ text_sensor:
       name: "balancer status"
     total_runtime_formatted:
       name: "total runtime formatted"
+    battery_status:
+      name: "battery status"
+    total_discharging_time_formatted:
+      name: "accumulated discharging time formatted"
+    total_charging_time_formatted:
+      name: "accumulated charging time formatted"
     device_model:
       name: "device model"
     software_version:

--- a/tests/components/ant_bms_ble/ant_bms_ble_test.cpp
+++ b/tests/components/ant_bms_ble/ant_bms_ble_test.cpp
@@ -172,6 +172,78 @@ TEST(AntBmsBleStatusDataTest, MosfetStatus) {
   EXPECT_FALSE(balancer.state);
 }
 
+// ── Battery status ────────────────────────────────────────────────────────────
+
+TEST(AntBmsBleStatusDataTest, BatteryStatus) {
+  TestableAntBmsBle bms;
+  sensor::Sensor code;
+  text_sensor::TextSensor txt;
+  bms.set_battery_status_code_sensor(&code);
+  bms.set_battery_status_text_sensor(&txt);
+
+  bms.assemble(STATUS_FRAME_16S.data(), STATUS_FRAME_16S.size());
+
+  EXPECT_FLOAT_EQ(code.state, 1.0f);
+  EXPECT_EQ(txt.state, "Idle");
+}
+
+// ── State of health ───────────────────────────────────────────────────────────
+
+TEST(AntBmsBleStatusDataTest, StateOfHealth) {
+  TestableAntBmsBle bms;
+  sensor::Sensor soh;
+  bms.set_state_of_health_sensor(&soh);
+
+  bms.assemble(STATUS_FRAME_16S.data(), STATUS_FRAME_16S.size());
+
+  EXPECT_FLOAT_EQ(soh.state, 100.0f);
+}
+
+// ── Balanced cell bitmask ─────────────────────────────────────────────────────
+
+TEST(AntBmsBleStatusDataTest, BalancedCellBitmask) {
+  TestableAntBmsBle bms;
+  sensor::Sensor bitmask;
+  bms.set_balanced_cell_bitmask_sensor(&bitmask);
+
+  bms.assemble(STATUS_FRAME_16S.data(), STATUS_FRAME_16S.size());
+
+  EXPECT_FLOAT_EQ(bitmask.state, 0.0f);
+}
+
+// ── Total capacity ──────────────────────────────────────────────────────
+
+TEST(AntBmsBleStatusDataTest, AccumulatedCapacity) {
+  TestableAntBmsBle bms;
+  sensor::Sensor dis_cap, chg_cap;
+  bms.set_total_discharging_capacity_sensor(&dis_cap);
+  bms.set_total_charging_capacity_sensor(&chg_cap);
+
+  bms.assemble(STATUS_FRAME_16S.data(), STATUS_FRAME_16S.size());
+
+  EXPECT_NEAR(dis_cap.state, 3902.649f, 0.01f);
+  EXPECT_NEAR(chg_cap.state, 5822.651f, 0.01f);
+}
+
+// ── Total time ──────────────────────────────────────────────────────────
+
+TEST(AntBmsBleStatusDataTest, AccumulatedTime) {
+  TestableAntBmsBle bms;
+  sensor::Sensor dis_time, chg_time;
+  text_sensor::TextSensor dis_fmt, chg_fmt;
+  bms.set_total_discharging_time_sensor(&dis_time);
+  bms.set_total_charging_time_sensor(&chg_time);
+  bms.set_total_discharging_time_formatted_text_sensor(&dis_fmt);
+  bms.set_total_charging_time_formatted_text_sensor(&chg_fmt);
+
+  bms.assemble(STATUS_FRAME_16S.data(), STATUS_FRAME_16S.size());
+
+  EXPECT_FLOAT_EQ(dis_time.state, 4402650.0f);
+  EXPECT_FLOAT_EQ(chg_time.state, 4830952.0f);
+  EXPECT_EQ(dis_fmt.state, "50d 22h");
+  EXPECT_EQ(chg_fmt.state, "55d 21h");
+}
+
 // ── Device info ───────────────────────────────────────────────────────────────
 
 TEST(AntBmsBleDeviceInfoTest, DeviceModel) {

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -93,7 +93,7 @@ class TestTextSensorConstants:
         assert ble_text_sensor.CONF_CHARGE_MOSFET_STATUS in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_DEVICE_MODEL in ble_text_sensor.TEXT_SENSORS
         assert ble_text_sensor.CONF_SOFTWARE_VERSION in ble_text_sensor.TEXT_SENSORS
-        assert len(ble_text_sensor.TEXT_SENSORS) == 6
+        assert len(ble_text_sensor.TEXT_SENSORS) == 9
 
 
 class TestSwitchConstants:


### PR DESCRIPTION
Closes #55

## Changes

New sensors extracted from the BLE status frame (previously only logged via `ESP_LOGI`):

**Numeric sensors (`sensor`):**
| Key | Unit | Description |
|---|---|---|
| `state_of_health` | % | Battery state of health |
| `battery_status_code` | - | Raw battery status code (0–5) |
| `total_discharging_capacity` | Ah | Total energy discharged over lifetime |
| `total_charging_capacity` | Ah | Total energy charged over lifetime |
| `total_discharging_time` | s | Total time spent discharging |
| `total_charging_time` | s | Total time spent charging |
| `balanced_cell_bitmask` | - | Bitmask of cells currently being balanced |

**Text sensors (`text_sensor`):**
| Key | Description |
|---|---|
| `battery_status` | Human-readable battery status (Idle / Charge / Discharge / Standby / Error) |
| `total_discharging_time_formatted` | Formatted discharging time (e.g. `50d 22h`) |
| `total_charging_time_formatted` | Formatted charging time (e.g. `55d 21h`) |

## Test coverage

C++ unit tests added for all new sensors using the existing 16S status frame fixture.