### PR TITLE
Add new button entities and replace bluetooth switch with buttons

### DIFF
--- a/components/ant_bms/ant_bms.cpp
+++ b/components/ant_bms/ant_bms.cpp
@@ -1,6 +1,7 @@
 #include "ant_bms.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include <array>
 
 namespace esphome::ant_bms {
 
@@ -144,7 +145,7 @@ bool AntBms::parse_ant_bms_byte_(uint8_t byte) {
 
   uint8_t function = raw[2];
 
-  uint16_t computed_crc = crc16_(raw + 1, frame_len - 5);
+  uint16_t computed_crc = crc16(raw + 1, frame_len - 5);
   uint16_t remote_crc = uint16_t(raw[frame_len - 3]) << 8 | (uint16_t(raw[frame_len - 4]) << 0);
   if (computed_crc != remote_crc) {
     ESP_LOGW(TAG, "CRC check failed! 0x%04X != 0x%04X", computed_crc, remote_crc);
@@ -385,7 +386,7 @@ void AntBms::update() {
   this->read_registers_();
 }
 
-void AntBms::write_register(uint8_t address, uint16_t value) { this->send_v2021_(0x51, address, value); }
+void AntBms::write_register(uint8_t address, uint16_t value) { this->send_(0x51, address, value); }
 
 void AntBms::track_online_status_() {
   if (this->no_response_count_ < MAX_NO_RESPONSE_COUNT) {
@@ -568,7 +569,7 @@ void AntBms::read_registers_() {
   frame[3] = 0x00;
   frame[4] = 0x00;
   frame[5] = 0xbe;
-  auto crc = crc16_(frame + 1, 5);
+  auto crc = crc16(frame + 1, 5);
   frame[6] = crc >> 0;
   frame[7] = crc >> 8;
   frame[8] = 0xaa;
@@ -578,7 +579,7 @@ void AntBms::read_registers_() {
   this->flush();
 }
 
-void AntBms::authenticate_v2021_() {
+void AntBms::authenticate_() {
   uint8_t frame[22];
 
   frame[0] = 0x7e;  // header
@@ -600,7 +601,7 @@ void AntBms::authenticate_v2021_() {
   frame[16] = 0x62;  // b
   frame[17] = 0x63;  // c
 
-  auto crc = crc16_(frame + 1, 17);
+  auto crc = crc16(frame + 1, 17);
   frame[18] = crc >> 0;  // CRC
   frame[19] = crc >> 8;  // CRC
 
@@ -611,13 +612,13 @@ void AntBms::authenticate_v2021_() {
   this->flush();
 }
 
-void AntBms::authenticate_v2021_variable_(const uint8_t *data, uint8_t data_len) {
+void AntBms::authenticate_variable_(const uint8_t *data, uint8_t data_len) {
   std::vector<uint8_t> frame = {0x7E, 0xA1, 0x23, 0x6A, 0x01};
   frame.push_back(data_len);
   for (int i = 0; i < data_len; i++) {
     frame.push_back(data[i]);
   }
-  auto crc = crc16_(frame.data() + 1, frame.size());
+  auto crc = crc16(frame.data() + 1, frame.size());
   frame.push_back(crc >> 0);
   frame.push_back(crc >> 8);
   frame.push_back(0xAA);
@@ -627,23 +628,26 @@ void AntBms::authenticate_v2021_variable_(const uint8_t *data, uint8_t data_len)
   this->flush();
 }
 
-void AntBms::send_v2021_(uint8_t function, uint8_t address, uint16_t value) {
-  this->authenticate_v2021_();
+std::array<uint8_t, 10> AntBms::build_frame(uint8_t function, uint8_t address, uint16_t value) {
+  std::array<uint8_t, 10> frame{};
+  frame[0] = 0x7e;
+  frame[1] = 0xa1;
+  frame[2] = function;
+  frame[3] = address;
+  frame[4] = value >> 8;
+  frame[5] = value >> 0;
+  auto crc = crc16(frame.data() + 1, 5);
+  frame[6] = crc >> 0;
+  frame[7] = crc >> 8;
+  frame[8] = 0xaa;
+  frame[9] = 0x55;
+  return frame;
+}
 
-  uint8_t frame[10];
-  frame[0] = 0x7e;        // header
-  frame[1] = 0xa1;        // header
-  frame[2] = function;    // control
-  frame[3] = address;     // address
-  frame[4] = value >> 8;  // value
-  frame[5] = value >> 0;  // value
-  auto crc = crc16_(frame + 1, 5);
-  frame[6] = crc >> 0;  // CRC
-  frame[7] = crc >> 8;  // CRC
-  frame[8] = 0xaa;      // footer
-  frame[9] = 0x55;      // footer
-
-  this->write_array(frame, 10);
+void AntBms::send_(uint8_t function, uint8_t address, uint16_t value) {
+  this->authenticate_();
+  auto frame = build_frame(function, address, value);
+  this->write_array(frame.data(), frame.size());
   this->flush();
 }
 

--- a/components/ant_bms/ant_bms.h
+++ b/components/ant_bms/ant_bms.h
@@ -6,6 +6,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
+#include <array>
 
 namespace esphome::ant_bms {
 
@@ -126,12 +127,12 @@ class AntBms : public uart::UARTDevice, public PollingComponent {
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
   void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
   void set_balancer_switch(switch_::Switch *balancer_switch) { balancer_switch_ = balancer_switch; }
-  void set_bluetooth_switch(switch_::Switch *bluetooth_switch) { bluetooth_switch_ = bluetooth_switch; }
   void set_buzzer_switch(switch_::Switch *buzzer_switch) { buzzer_switch_ = buzzer_switch; }
 
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
 
   void on_ant_bms_data(const std::vector<uint8_t> &data);
+  static std::array<uint8_t, 10> build_frame(uint8_t function, uint8_t address, uint16_t value);
   void write_register(uint8_t address, uint16_t value);
 
  protected:
@@ -166,7 +167,6 @@ class AntBms : public uart::UARTDevice, public PollingComponent {
   switch_::Switch *charging_switch_{nullptr};
   switch_::Switch *discharging_switch_{nullptr};
   switch_::Switch *balancer_switch_{nullptr};
-  switch_::Switch *bluetooth_switch_{nullptr};
   switch_::Switch *buzzer_switch_{nullptr};
 
   text_sensor::TextSensor *charge_mosfet_status_text_sensor_{nullptr};
@@ -196,19 +196,19 @@ class AntBms : public uart::UARTDevice, public PollingComponent {
   void on_status_data_(const std::vector<uint8_t> &data);
   void on_device_info_data_(const std::vector<uint8_t> &data);
   bool parse_ant_bms_byte_(uint8_t byte);
-  void authenticate_v2021_();
-  void authenticate_v2021_variable_(const uint8_t *data, uint8_t data_len);
+  void authenticate_();
+  void authenticate_variable_(const uint8_t *data, uint8_t data_len);
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(switch_::Switch *obj, const bool &state);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
   void read_registers_();
-  void send_v2021_(uint8_t function, uint8_t address, uint16_t value);
+  void send_(uint8_t function, uint8_t address, uint16_t value);
   void publish_device_unavailable_();
   void reset_online_status_tracker_();
   void track_online_status_();
 
-  uint16_t crc16_(const uint8_t *data, uint8_t len) {
+  static uint16_t crc16(const uint8_t *data, uint8_t len) {
     uint16_t crc = 0xFFFF;
     while (len--) {
       crc ^= *data++;

--- a/components/ant_bms/button/__init__.py
+++ b/components/ant_bms/button/__init__.py
@@ -13,15 +13,39 @@ CODEOWNERS = ["@syssi"]
 CONF_SHUTDOWN = "shutdown"
 # CONF_FACTORY_RESET = "factory_reset"
 CONF_CLEAR_SYSTEM_LOG = "clear_system_log"
+CONF_CURRENT_ZERO = "current_zero"
+CONF_RESET_HARDWARE = "reset_hardware"
+CONF_BLUETOOTH_INITIALIZATION = "bluetooth_initialization"
+CONF_SAVE_CUSTOMER_DATA = "save_customer_data"
+CONF_CLEAR_DISCHARGE_CYCLE_AH = "clear_discharge_cycle_ah"
+CONF_CLEAR_CHARGE_CYCLE_AH = "clear_charge_cycle_ah"
+CONF_CLEAR_DISCHARGE_TIME = "clear_discharge_time"
+CONF_CLEAR_CHARGE_TIME = "clear_charge_time"
+CONF_CLEAR_RUNNING_TIME = "clear_running_time"
+CONF_CLEAR_PROTECT_TIME = "clear_protect_time"
+CONF_BLUETOOTH_ON = "bluetooth_on"
+CONF_BLUETOOTH_OFF = "bluetooth_off"
 
 ICON_RESTART = "mdi:restart"
 ICON_SHUTDOWN = "mdi:power"
 ICON_FACTORY_RESET = "mdi:factory"
 ICON_CLEAR_SYSTEM_LOG = "mdi:delete-clock"
+ICON_CURRENT_ZERO = "mdi:current-dc"
+ICON_RESET_HARDWARE = "mdi:restart-alert"
+ICON_BLUETOOTH_INITIALIZATION = "mdi:bluetooth-settings"
+ICON_SAVE_CUSTOMER_DATA = "mdi:content-save"
+ICON_CLEAR_AH = "mdi:counter"
+ICON_CLEAR_TIME = "mdi:timer-off"
+ICON_BLUETOOTH_ON = "mdi:bluetooth-connect"
+ICON_BLUETOOTH_OFF = "mdi:bluetooth-off"
 
-# Not implemented yet
+# Buttons (from https://github.com/syssi/esphome-ant-bms/issues/29)
 #
 # Current Zero                7e a1 51 08 00 00 08 e7 aa 55
+# Restart                     7e a1 51 09 00 00 59 27 aa 55
+# Shutdown                    7e a1 51 0b 00 00 f8 e7 aa 55
+# Factory reset               7e a1 51 0c 00 00 49 26 aa 55
+# Clear System Log            7e a1 51 0f 00 00 b9 26 aa 55
 # Bluetooth initialization    7e a1 51 10 00 00 88 e0 aa 55
 # Clear Discharge Cycle Ah    7e a1 51 20 00 00 88 ef aa 55
 # Clear Charge Cycle Ah       7e a1 51 21 00 00 d9 2f aa 55
@@ -31,37 +55,77 @@ ICON_CLEAR_SYSTEM_LOG = "mdi:delete-clock"
 # Clear Protect Time          7e a1 51 25 00 00 98 ee aa 55
 # Reset hardware              7e a1 51 2a 00 00 a8 ed aa 55
 # Save Customer Data          7e a1 51 2c 00 00 48 ec aa 55
-#
-# https://github.com/syssi/esphome-ant-bms/issues/20
-# https://github.com/syssi/esphome-ant-bms/issues/29
+# Bluetooth on                7e a1 51 1d 00 00 19 23 aa 55
+# Bluetooth off               7e a1 51 1c 00 00 48 e3 aa 55
 
 BUTTONS = {
+    CONF_CURRENT_ZERO: 0x0008,
     CONF_RESTART: 0x0009,
     CONF_SHUTDOWN: 0x000B,
     CONF_FACTORY_RESET: 0x000C,
     CONF_CLEAR_SYSTEM_LOG: 0x000F,
+    CONF_BLUETOOTH_INITIALIZATION: 0x0010,
+    CONF_BLUETOOTH_OFF: 0x001C,
+    CONF_BLUETOOTH_ON: 0x001D,
+    CONF_CLEAR_DISCHARGE_CYCLE_AH: 0x0020,
+    CONF_CLEAR_CHARGE_CYCLE_AH: 0x0021,
+    CONF_CLEAR_DISCHARGE_TIME: 0x0022,
+    CONF_CLEAR_CHARGE_TIME: 0x0023,
+    CONF_CLEAR_RUNNING_TIME: 0x0024,
+    CONF_CLEAR_PROTECT_TIME: 0x0025,
+    CONF_RESET_HARDWARE: 0x002A,
+    CONF_SAVE_CUSTOMER_DATA: 0x002C,
 }
-
-# Available as button entities
-#
-# Restart                     7e a1 51 09 00 00 59 27 aa 55
-# Shutdown                    7e a1 51 0b 00 00 f8 e7 aa 55
-# Factory reset               7e a1 51 0c 00 00 49 26 aa 55
-# Clear System Log            7e a1 51 0f 00 00 b9 26 aa 55
 
 AntButton = ant_bms_ns.class_("AntButton", button.Button, cg.Component)
 
 CONFIG_SCHEMA = ANT_BMS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_SHUTDOWN): button.button_schema(AntButton, icon=ICON_SHUTDOWN),
-        cv.Optional(CONF_CLEAR_SYSTEM_LOG): button.button_schema(
-            AntButton, icon=ICON_CLEAR_SYSTEM_LOG
-        ),
-        cv.Optional(CONF_FACTORY_RESET): button.button_schema(
-            AntButton, icon=ICON_FACTORY_RESET, device_class=DEVICE_CLASS_RESTART
+        cv.Optional(CONF_CURRENT_ZERO): button.button_schema(
+            AntButton, icon=ICON_CURRENT_ZERO
         ),
         cv.Optional(CONF_RESTART): button.button_schema(
             AntButton, icon=ICON_RESTART, device_class=DEVICE_CLASS_RESTART
+        ),
+        cv.Optional(CONF_SHUTDOWN): button.button_schema(AntButton, icon=ICON_SHUTDOWN),
+        cv.Optional(CONF_FACTORY_RESET): button.button_schema(
+            AntButton, icon=ICON_FACTORY_RESET, device_class=DEVICE_CLASS_RESTART
+        ),
+        cv.Optional(CONF_CLEAR_SYSTEM_LOG): button.button_schema(
+            AntButton, icon=ICON_CLEAR_SYSTEM_LOG
+        ),
+        cv.Optional(CONF_BLUETOOTH_INITIALIZATION): button.button_schema(
+            AntButton, icon=ICON_BLUETOOTH_INITIALIZATION
+        ),
+        cv.Optional(CONF_BLUETOOTH_OFF): button.button_schema(
+            AntButton, icon=ICON_BLUETOOTH_OFF
+        ),
+        cv.Optional(CONF_BLUETOOTH_ON): button.button_schema(
+            AntButton, icon=ICON_BLUETOOTH_ON
+        ),
+        cv.Optional(CONF_CLEAR_DISCHARGE_CYCLE_AH): button.button_schema(
+            AntButton, icon=ICON_CLEAR_AH
+        ),
+        cv.Optional(CONF_CLEAR_CHARGE_CYCLE_AH): button.button_schema(
+            AntButton, icon=ICON_CLEAR_AH
+        ),
+        cv.Optional(CONF_CLEAR_DISCHARGE_TIME): button.button_schema(
+            AntButton, icon=ICON_CLEAR_TIME
+        ),
+        cv.Optional(CONF_CLEAR_CHARGE_TIME): button.button_schema(
+            AntButton, icon=ICON_CLEAR_TIME
+        ),
+        cv.Optional(CONF_CLEAR_RUNNING_TIME): button.button_schema(
+            AntButton, icon=ICON_CLEAR_TIME
+        ),
+        cv.Optional(CONF_CLEAR_PROTECT_TIME): button.button_schema(
+            AntButton, icon=ICON_CLEAR_TIME
+        ),
+        cv.Optional(CONF_RESET_HARDWARE): button.button_schema(
+            AntButton, icon=ICON_RESET_HARDWARE
+        ),
+        cv.Optional(CONF_SAVE_CUSTOMER_DATA): button.button_schema(
+            AntButton, icon=ICON_SAVE_CUSTOMER_DATA
         ),
     }
 )

--- a/components/ant_bms/switch/__init__.py
+++ b/components/ant_bms/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_BLUETOOTH, ENTITY_CATEGORY_CONFIG
+from esphome.const import ENTITY_CATEGORY_CONFIG
 
 from .. import ANT_BMS_COMPONENT_SCHEMA, CONF_ANT_BMS_ID, ant_bms_ns
 from ..const import CONF_BALANCER, CONF_CHARGING, CONF_DISCHARGING
@@ -16,7 +16,6 @@ CONF_BUZZER = "buzzer"
 ICON_DISCHARGING = "mdi:battery-charging-50"
 ICON_CHARGING = "mdi:battery-charging-50"
 ICON_BALANCER = "mdi:seesaw"
-ICON_BLUETOOTH = "mdi:bluetooth"
 ICON_BUZZER = "mdi:volume-high"
 
 SWITCHES = {
@@ -24,7 +23,6 @@ SWITCHES = {
     CONF_DISCHARGING: [0x0003, 0x0001],
     CONF_CHARGING: [0x0006, 0x0004],
     CONF_BALANCER: [0x000D, 0x000E],
-    CONF_BLUETOOTH: [0x001D, 0x001C],
     CONF_BUZZER: [0x001E, 0x001F],
 }
 
@@ -50,11 +48,6 @@ CONFIG_SCHEMA = ANT_BMS_COMPONENT_SCHEMA.extend(
         ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(AntSwitch, icon=ICON_CHARGING),
         cv.Optional(CONF_BALANCER): switch.switch_schema(AntSwitch, icon=ICON_BALANCER),
-        cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
-            AntSwitch,
-            icon=ICON_BLUETOOTH,
-            entity_category=ENTITY_CATEGORY_CONFIG,
-        ),
         cv.Optional(CONF_BUZZER): switch.switch_schema(
             AntSwitch,
             icon=ICON_BUZZER,

--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/version.h"
+#include <array>
 
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 12, 0)
 #define ADDR_STR(x) x
@@ -219,7 +220,7 @@ void AntBmsBle::assemble(const uint8_t *data, uint16_t length) {
       return;
     }
 
-    uint16_t computed_crc = crc16_(raw + 1, frame_len - 5);
+    uint16_t computed_crc = crc16(raw + 1, frame_len - 5);
     uint16_t remote_crc = uint16_t(raw[frame_len - 3]) << 8 | (uint16_t(raw[frame_len - 4]) << 0);
     if (computed_crc != remote_crc) {
       ESP_LOGW(TAG, "CRC Check failed! %04X != %04X", computed_crc, remote_crc);
@@ -666,6 +667,22 @@ void AntBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std::
   text_sensor->publish_state(state);
 }
 
+std::array<uint8_t, 10> AntBmsBle::build_frame(uint8_t function, uint16_t address, uint8_t value) {
+  std::array<uint8_t, 10> frame{};
+  frame[0] = 0x7e;
+  frame[1] = 0xa1;
+  frame[2] = function;
+  frame[3] = address >> 0;
+  frame[4] = address >> 8;
+  frame[5] = value;
+  auto crc = crc16(frame.data() + 1, 5);
+  frame[6] = crc >> 0;
+  frame[7] = crc >> 8;
+  frame[8] = 0xaa;
+  frame[9] = 0x55;
+  return frame;
+}
+
 #ifdef USE_ESP32
 void AntBmsBle::write_register(uint16_t address, uint8_t value) {
   this->send_(ANT_COMMAND_WRITE_REGISTER, address, value, true);
@@ -693,7 +710,7 @@ bool AntBmsBle::authenticate_() {
   frame[16] = 0x62;  // b
   frame[17] = 0x63;  // c
 
-  auto crc = crc16_(frame + 1, 17);
+  auto crc = crc16(frame + 1, 17);
   frame[18] = crc >> 0;  // CRC
   frame[19] = crc >> 8;  // CRC
 
@@ -717,7 +734,7 @@ bool AntBmsBle::authenticate_variable_(const uint8_t *data, uint8_t data_len) {
   for (int i = 0; i < data_len; i++) {
     frame.push_back(data[i]);
   }
-  auto crc = crc16_(frame.data() + 1, frame.size());
+  auto crc = crc16(frame.data() + 1, frame.size());
   frame.push_back(crc >> 0);
   frame.push_back(crc >> 8);
   frame.push_back(0xAA);
@@ -734,28 +751,17 @@ bool AntBmsBle::authenticate_variable_(const uint8_t *data, uint8_t data_len) {
   return (status == 0);
 }
 
-bool AntBmsBle::send_(uint8_t function, uint16_t address, uint8_t value, bool authenticate = true) {
+bool AntBmsBle::send_(uint8_t function, uint16_t address, uint8_t value, bool authenticate) {
   if (authenticate) {
     this->authenticate_();
   }
 
-  uint8_t frame[10];
-  frame[0] = 0x7e;          // header
-  frame[1] = 0xa1;          // header
-  frame[2] = function;      // control
-  frame[3] = address >> 0;  // address
-  frame[4] = address >> 8;  // address
-  frame[5] = value;         // value
-  auto crc = crc16_(frame + 1, 5);
-  frame[6] = crc >> 0;  // CRC
-  frame[7] = crc >> 8;  // CRC
-  frame[8] = 0xaa;      // footer
-  frame[9] = 0x55;      // footer
+  auto frame = build_frame(function, address, value);
 
-  ESP_LOGVV(TAG, "Send command: %s", format_hex_pretty(frame, sizeof(frame)).c_str());  // NOLINT
+  ESP_LOGVV(TAG, "Send command: %s", format_hex_pretty(frame.data(), frame.size()).c_str());  // NOLINT
   auto status = esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(),
-                                         this->characteristic_handle_, sizeof(frame), frame, ESP_GATT_WRITE_TYPE_NO_RSP,
-                                         ESP_GATT_AUTH_REQ_NONE);
+                                         this->characteristic_handle_, frame.size(), frame.data(),
+                                         ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
 
   if (status)
     ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", ADDR_STR(this->parent_->address_str()), status);

--- a/components/ant_bms_ble/ant_bms_ble.h
+++ b/components/ant_bms_ble/ant_bms_ble.h
@@ -5,6 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include <array>
 
 #ifdef USE_ESP32
 #include "esphome/components/ble_client/ble_client.h"
@@ -139,12 +140,12 @@ class AntBmsBle :
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
   void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
   void set_balancer_switch(switch_::Switch *balancer_switch) { balancer_switch_ = balancer_switch; }
-  void set_bluetooth_switch(switch_::Switch *bluetooth_switch) { bluetooth_switch_ = bluetooth_switch; }
   void set_buzzer_switch(switch_::Switch *buzzer_switch) { buzzer_switch_ = buzzer_switch; }
 
   void set_password(const std::string &password) { this->password_ = password; }
 
   void assemble(const uint8_t *data, uint16_t length);
+  static std::array<uint8_t, 10> build_frame(uint8_t function, uint16_t address, uint8_t value);
   void write_register(uint16_t address, uint8_t value);
 
  protected:
@@ -179,7 +180,6 @@ class AntBmsBle :
   switch_::Switch *charging_switch_{nullptr};
   switch_::Switch *discharging_switch_{nullptr};
   switch_::Switch *balancer_switch_{nullptr};
-  switch_::Switch *bluetooth_switch_{nullptr};
   switch_::Switch *buzzer_switch_{nullptr};
 
   text_sensor::TextSensor *charge_mosfet_status_text_sensor_{nullptr};
@@ -220,7 +220,7 @@ class AntBmsBle :
   void reset_online_status_tracker_();
   void track_online_status_();
 
-  uint16_t crc16_(const uint8_t *data, uint8_t len) {
+  static uint16_t crc16(const uint8_t *data, uint8_t len) {
     uint16_t crc = 0xFFFF;
     while (len--) {
       crc ^= *data++;

--- a/components/ant_bms_ble/button/__init__.py
+++ b/components/ant_bms_ble/button/__init__.py
@@ -13,15 +13,39 @@ CODEOWNERS = ["@syssi"]
 CONF_SHUTDOWN = "shutdown"
 # CONF_FACTORY_RESET = "factory_reset"
 CONF_CLEAR_SYSTEM_LOG = "clear_system_log"
+CONF_CURRENT_ZERO = "current_zero"
+CONF_RESET_HARDWARE = "reset_hardware"
+CONF_BLUETOOTH_INITIALIZATION = "bluetooth_initialization"
+CONF_SAVE_CUSTOMER_DATA = "save_customer_data"
+CONF_CLEAR_DISCHARGE_CYCLE_AH = "clear_discharge_cycle_ah"
+CONF_CLEAR_CHARGE_CYCLE_AH = "clear_charge_cycle_ah"
+CONF_CLEAR_DISCHARGE_TIME = "clear_discharge_time"
+CONF_CLEAR_CHARGE_TIME = "clear_charge_time"
+CONF_CLEAR_RUNNING_TIME = "clear_running_time"
+CONF_CLEAR_PROTECT_TIME = "clear_protect_time"
+CONF_BLUETOOTH_ON = "bluetooth_on"
+CONF_BLUETOOTH_OFF = "bluetooth_off"
 
 ICON_RESTART = "mdi:restart"
 ICON_SHUTDOWN = "mdi:power"
 ICON_FACTORY_RESET = "mdi:factory"
 ICON_CLEAR_SYSTEM_LOG = "mdi:delete-clock"
+ICON_CURRENT_ZERO = "mdi:current-dc"
+ICON_RESET_HARDWARE = "mdi:restart-alert"
+ICON_BLUETOOTH_INITIALIZATION = "mdi:bluetooth-settings"
+ICON_SAVE_CUSTOMER_DATA = "mdi:content-save"
+ICON_CLEAR_AH = "mdi:counter"
+ICON_CLEAR_TIME = "mdi:timer-off"
+ICON_BLUETOOTH_ON = "mdi:bluetooth-connect"
+ICON_BLUETOOTH_OFF = "mdi:bluetooth-off"
 
-# Not implemented yet
+# Buttons (from https://github.com/syssi/esphome-ant-bms/issues/29)
 #
 # Current Zero                7e a1 51 08 00 00 08 e7 aa 55
+# Restart                     7e a1 51 09 00 00 59 27 aa 55
+# Shutdown                    7e a1 51 0b 00 00 f8 e7 aa 55
+# Factory reset               7e a1 51 0c 00 00 49 26 aa 55
+# Clear System Log            7e a1 51 0f 00 00 b9 26 aa 55
 # Bluetooth initialization    7e a1 51 10 00 00 88 e0 aa 55
 # Clear Discharge Cycle Ah    7e a1 51 20 00 00 88 ef aa 55
 # Clear Charge Cycle Ah       7e a1 51 21 00 00 d9 2f aa 55
@@ -31,37 +55,77 @@ ICON_CLEAR_SYSTEM_LOG = "mdi:delete-clock"
 # Clear Protect Time          7e a1 51 25 00 00 98 ee aa 55
 # Reset hardware              7e a1 51 2a 00 00 a8 ed aa 55
 # Save Customer Data          7e a1 51 2c 00 00 48 ec aa 55
-#
-# https://github.com/syssi/esphome-ant-bms/issues/20
-# https://github.com/syssi/esphome-ant-bms/issues/29
+# Bluetooth on                7e a1 51 1d 00 00 19 23 aa 55
+# Bluetooth off               7e a1 51 1c 00 00 48 e3 aa 55
 
 BUTTONS = {
+    CONF_CURRENT_ZERO: 0x0008,
     CONF_RESTART: 0x0009,
     CONF_SHUTDOWN: 0x000B,
     CONF_FACTORY_RESET: 0x000C,
     CONF_CLEAR_SYSTEM_LOG: 0x000F,
+    CONF_BLUETOOTH_INITIALIZATION: 0x0010,
+    CONF_BLUETOOTH_OFF: 0x001C,
+    CONF_BLUETOOTH_ON: 0x001D,
+    CONF_CLEAR_DISCHARGE_CYCLE_AH: 0x0020,
+    CONF_CLEAR_CHARGE_CYCLE_AH: 0x0021,
+    CONF_CLEAR_DISCHARGE_TIME: 0x0022,
+    CONF_CLEAR_CHARGE_TIME: 0x0023,
+    CONF_CLEAR_RUNNING_TIME: 0x0024,
+    CONF_CLEAR_PROTECT_TIME: 0x0025,
+    CONF_RESET_HARDWARE: 0x002A,
+    CONF_SAVE_CUSTOMER_DATA: 0x002C,
 }
-
-# Available as button entities
-#
-# Restart                     7e a1 51 09 00 00 59 27 aa 55
-# Shutdown                    7e a1 51 0b 00 00 f8 e7 aa 55
-# Factory reset               7e a1 51 0c 00 00 49 26 aa 55
-# Clear System Log            7e a1 51 0f 00 00 b9 26 aa 55
 
 AntButton = ant_bms_ble_ns.class_("AntButton", button.Button, cg.Component)
 
 CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_SHUTDOWN): button.button_schema(AntButton, icon=ICON_SHUTDOWN),
-        cv.Optional(CONF_CLEAR_SYSTEM_LOG): button.button_schema(
-            AntButton, icon=ICON_CLEAR_SYSTEM_LOG
-        ),
-        cv.Optional(CONF_FACTORY_RESET): button.button_schema(
-            AntButton, icon=ICON_FACTORY_RESET, device_class=DEVICE_CLASS_RESTART
+        cv.Optional(CONF_CURRENT_ZERO): button.button_schema(
+            AntButton, icon=ICON_CURRENT_ZERO
         ),
         cv.Optional(CONF_RESTART): button.button_schema(
             AntButton, icon=ICON_RESTART, device_class=DEVICE_CLASS_RESTART
+        ),
+        cv.Optional(CONF_SHUTDOWN): button.button_schema(AntButton, icon=ICON_SHUTDOWN),
+        cv.Optional(CONF_FACTORY_RESET): button.button_schema(
+            AntButton, icon=ICON_FACTORY_RESET, device_class=DEVICE_CLASS_RESTART
+        ),
+        cv.Optional(CONF_CLEAR_SYSTEM_LOG): button.button_schema(
+            AntButton, icon=ICON_CLEAR_SYSTEM_LOG
+        ),
+        cv.Optional(CONF_BLUETOOTH_INITIALIZATION): button.button_schema(
+            AntButton, icon=ICON_BLUETOOTH_INITIALIZATION
+        ),
+        cv.Optional(CONF_BLUETOOTH_OFF): button.button_schema(
+            AntButton, icon=ICON_BLUETOOTH_OFF
+        ),
+        cv.Optional(CONF_BLUETOOTH_ON): button.button_schema(
+            AntButton, icon=ICON_BLUETOOTH_ON
+        ),
+        cv.Optional(CONF_CLEAR_DISCHARGE_CYCLE_AH): button.button_schema(
+            AntButton, icon=ICON_CLEAR_AH
+        ),
+        cv.Optional(CONF_CLEAR_CHARGE_CYCLE_AH): button.button_schema(
+            AntButton, icon=ICON_CLEAR_AH
+        ),
+        cv.Optional(CONF_CLEAR_DISCHARGE_TIME): button.button_schema(
+            AntButton, icon=ICON_CLEAR_TIME
+        ),
+        cv.Optional(CONF_CLEAR_CHARGE_TIME): button.button_schema(
+            AntButton, icon=ICON_CLEAR_TIME
+        ),
+        cv.Optional(CONF_CLEAR_RUNNING_TIME): button.button_schema(
+            AntButton, icon=ICON_CLEAR_TIME
+        ),
+        cv.Optional(CONF_CLEAR_PROTECT_TIME): button.button_schema(
+            AntButton, icon=ICON_CLEAR_TIME
+        ),
+        cv.Optional(CONF_RESET_HARDWARE): button.button_schema(
+            AntButton, icon=ICON_RESET_HARDWARE
+        ),
+        cv.Optional(CONF_SAVE_CUSTOMER_DATA): button.button_schema(
+            AntButton, icon=ICON_SAVE_CUSTOMER_DATA
         ),
     }
 )

--- a/components/ant_bms_ble/switch/__init__.py
+++ b/components/ant_bms_ble/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_BLUETOOTH, ENTITY_CATEGORY_CONFIG
+from esphome.const import ENTITY_CATEGORY_CONFIG
 
 from .. import ANT_BMS_BLE_COMPONENT_SCHEMA, CONF_ANT_BMS_BLE_ID, ant_bms_ble_ns
 from ..const import CONF_BALANCER, CONF_CHARGING, CONF_DISCHARGING
@@ -16,7 +16,6 @@ CONF_BUZZER = "buzzer"
 ICON_DISCHARGING = "mdi:battery-charging-50"
 ICON_CHARGING = "mdi:battery-charging-50"
 ICON_BALANCER = "mdi:seesaw"
-ICON_BLUETOOTH = "mdi:bluetooth"
 ICON_BUZZER = "mdi:volume-high"
 
 SWITCHES = {
@@ -24,7 +23,6 @@ SWITCHES = {
     CONF_DISCHARGING: [0x0003, 0x0001],
     CONF_CHARGING: [0x0006, 0x0004],
     CONF_BALANCER: [0x000D, 0x000E],
-    CONF_BLUETOOTH: [0x001D, 0x001C],
     CONF_BUZZER: [0x001E, 0x001F],
 }
 
@@ -50,11 +48,6 @@ CONFIG_SCHEMA = ANT_BMS_BLE_COMPONENT_SCHEMA.extend(
         ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(AntSwitch, icon=ICON_CHARGING),
         cv.Optional(CONF_BALANCER): switch.switch_schema(AntSwitch, icon=ICON_BALANCER),
-        cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
-            AntSwitch,
-            icon=ICON_BLUETOOTH,
-            entity_category=ENTITY_CATEGORY_CONFIG,
-        ),
         cv.Optional(CONF_BUZZER): switch.switch_schema(
             AntSwitch,
             icon=ICON_BUZZER,

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -517,6 +517,9 @@ switch:
 button:
   - platform: ant_bms_ble
     ant_bms_ble_id: bms0
+    current_zero:
+      name: "current zero"
+      device_id: device0
     shutdown:
       name: "shutdown"
       device_id: device0
@@ -528,10 +531,46 @@ button:
       device_id: device0
     restart:
       name: "restart"
+      device_id: device0
+    bluetooth_initialization:
+      name: "bluetooth initialization"
+      device_id: device0
+    bluetooth_off:
+      name: "bluetooth off"
+      device_id: device0
+    bluetooth_on:
+      name: "bluetooth on"
+      device_id: device0
+    clear_discharge_cycle_ah:
+      name: "clear discharge cycle ah"
+      device_id: device0
+    clear_charge_cycle_ah:
+      name: "clear charge cycle ah"
+      device_id: device0
+    clear_discharge_time:
+      name: "clear discharge time"
+      device_id: device0
+    clear_charge_time:
+      name: "clear charge time"
+      device_id: device0
+    clear_running_time:
+      name: "clear running time"
+      device_id: device0
+    clear_protect_time:
+      name: "clear protect time"
+      device_id: device0
+    reset_hardware:
+      name: "reset hardware"
+      device_id: device0
+    save_customer_data:
+      name: "save customer data"
       device_id: device0
 
   - platform: ant_bms_ble
     ant_bms_ble_id: bms1
+    current_zero:
+      name: "current zero"
+      device_id: device1
     shutdown:
       name: "shutdown"
       device_id: device1
@@ -543,4 +582,37 @@ button:
       device_id: device1
     restart:
       name: "restart"
+      device_id: device1
+    bluetooth_initialization:
+      name: "bluetooth initialization"
+      device_id: device1
+    bluetooth_off:
+      name: "bluetooth off"
+      device_id: device1
+    bluetooth_on:
+      name: "bluetooth on"
+      device_id: device1
+    clear_discharge_cycle_ah:
+      name: "clear discharge cycle ah"
+      device_id: device1
+    clear_charge_cycle_ah:
+      name: "clear charge cycle ah"
+      device_id: device1
+    clear_discharge_time:
+      name: "clear discharge time"
+      device_id: device1
+    clear_charge_time:
+      name: "clear charge time"
+      device_id: device1
+    clear_running_time:
+      name: "clear running time"
+      device_id: device1
+    clear_protect_time:
+      name: "clear protect time"
+      device_id: device1
+    reset_hardware:
+      name: "reset hardware"
+      device_id: device1
+    save_customer_data:
+      name: "save customer data"
       device_id: device1

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -236,6 +236,8 @@ switch:
 button:
   - platform: ant_bms_ble
     ant_bms_ble_id: bms0
+    current_zero:
+      name: "current zero"
     shutdown:
       name: "shutdown"
     clear_system_log:
@@ -244,3 +246,25 @@ button:
       name: "factory reset"
     restart:
       name: "restart"
+    bluetooth_initialization:
+      name: "bluetooth initialization"
+    bluetooth_off:
+      name: "bluetooth off"
+    bluetooth_on:
+      name: "bluetooth on"
+    clear_discharge_cycle_ah:
+      name: "clear discharge cycle ah"
+    clear_charge_cycle_ah:
+      name: "clear charge cycle ah"
+    clear_discharge_time:
+      name: "clear discharge time"
+    clear_charge_time:
+      name: "clear charge time"
+    clear_running_time:
+      name: "clear running time"
+    clear_protect_time:
+      name: "clear protect time"
+    reset_hardware:
+      name: "reset hardware"
+    save_customer_data:
+      name: "save customer data"

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -566,6 +566,9 @@ switch:
 button:
   - platform: ant_bms
     ant_bms_id: bms0
+    current_zero:
+      name: "current zero"
+      device_id: device0
     shutdown:
       name: "shutdown"
       device_id: device0
@@ -577,10 +580,46 @@ button:
       device_id: device0
     restart:
       name: "restart"
+      device_id: device0
+    bluetooth_initialization:
+      name: "bluetooth initialization"
+      device_id: device0
+    bluetooth_off:
+      name: "bluetooth off"
+      device_id: device0
+    bluetooth_on:
+      name: "bluetooth on"
+      device_id: device0
+    clear_discharge_cycle_ah:
+      name: "clear discharge cycle ah"
+      device_id: device0
+    clear_charge_cycle_ah:
+      name: "clear charge cycle ah"
+      device_id: device0
+    clear_discharge_time:
+      name: "clear discharge time"
+      device_id: device0
+    clear_charge_time:
+      name: "clear charge time"
+      device_id: device0
+    clear_running_time:
+      name: "clear running time"
+      device_id: device0
+    clear_protect_time:
+      name: "clear protect time"
+      device_id: device0
+    reset_hardware:
+      name: "reset hardware"
+      device_id: device0
+    save_customer_data:
+      name: "save customer data"
       device_id: device0
 
   - platform: ant_bms
     ant_bms_id: bms1
+    current_zero:
+      name: "current zero"
+      device_id: device1
     shutdown:
       name: "shutdown"
       device_id: device1
@@ -592,4 +631,37 @@ button:
       device_id: device1
     restart:
       name: "restart"
+      device_id: device1
+    bluetooth_initialization:
+      name: "bluetooth initialization"
+      device_id: device1
+    bluetooth_off:
+      name: "bluetooth off"
+      device_id: device1
+    bluetooth_on:
+      name: "bluetooth on"
+      device_id: device1
+    clear_discharge_cycle_ah:
+      name: "clear discharge cycle ah"
+      device_id: device1
+    clear_charge_cycle_ah:
+      name: "clear charge cycle ah"
+      device_id: device1
+    clear_discharge_time:
+      name: "clear discharge time"
+      device_id: device1
+    clear_charge_time:
+      name: "clear charge time"
+      device_id: device1
+    clear_running_time:
+      name: "clear running time"
+      device_id: device1
+    clear_protect_time:
+      name: "clear protect time"
+      device_id: device1
+    reset_hardware:
+      name: "reset hardware"
+      device_id: device1
+    save_customer_data:
+      name: "save customer data"
       device_id: device1

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -229,6 +229,8 @@ switch:
 button:
   - platform: ant_bms
     ant_bms_id: bms0
+    current_zero:
+      name: "current zero"
     shutdown:
       name: "shutdown"
     clear_system_log:
@@ -237,3 +239,25 @@ button:
       name: "factory reset"
     restart:
       name: "restart"
+    bluetooth_initialization:
+      name: "bluetooth initialization"
+    bluetooth_off:
+      name: "bluetooth off"
+    bluetooth_on:
+      name: "bluetooth on"
+    clear_discharge_cycle_ah:
+      name: "clear discharge cycle ah"
+    clear_charge_cycle_ah:
+      name: "clear charge cycle ah"
+    clear_discharge_time:
+      name: "clear discharge time"
+    clear_charge_time:
+      name: "clear charge time"
+    clear_running_time:
+      name: "clear running time"
+    clear_protect_time:
+      name: "clear protect time"
+    reset_hardware:
+      name: "reset hardware"
+    save_customer_data:
+      name: "save customer data"

--- a/tests/components/ant_bms/ant_bms_test.cpp
+++ b/tests/components/ant_bms/ant_bms_test.cpp
@@ -287,4 +287,102 @@ TEST(AntBmsDeviceInfoTest, ShortDeviceInfoFrameIgnored) {
   EXPECT_EQ(model.state, "");
 }
 
+// -- Frame builder ------------------------------------------------------------
+
+TEST(AntBmsFrameBuilderTest, CurrentZero) {
+  auto frame = AntBms::build_frame_(0x51, 0x08, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x08, 0x00, 0x00, 0x08, 0xe7, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, Restart) {
+  auto frame = AntBms::build_frame_(0x51, 0x09, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x09, 0x00, 0x00, 0x59, 0x27, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, Shutdown) {
+  auto frame = AntBms::build_frame_(0x51, 0x0b, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0b, 0x00, 0x00, 0xf8, 0xe7, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, FactoryReset) {
+  auto frame = AntBms::build_frame_(0x51, 0x0c, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0c, 0x00, 0x00, 0x49, 0x26, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, ClearSystemLog) {
+  auto frame = AntBms::build_frame_(0x51, 0x0f, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0f, 0x00, 0x00, 0xb9, 0x26, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, BluetoothInitialization) {
+  auto frame = AntBms::build_frame_(0x51, 0x10, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x10, 0x00, 0x00, 0x88, 0xe0, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, BluetoothOff) {
+  auto frame = AntBms::build_frame_(0x51, 0x1c, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x1c, 0x00, 0x00, 0x48, 0xe3, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, BluetoothOn) {
+  auto frame = AntBms::build_frame_(0x51, 0x1d, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x1d, 0x00, 0x00, 0x19, 0x23, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, ClearDischargeCycleAh) {
+  auto frame = AntBms::build_frame_(0x51, 0x20, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x20, 0x00, 0x00, 0x88, 0xef, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, ClearChargeCycleAh) {
+  auto frame = AntBms::build_frame_(0x51, 0x21, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x21, 0x00, 0x00, 0xd9, 0x2f, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, ClearDischargeTime) {
+  auto frame = AntBms::build_frame_(0x51, 0x22, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x22, 0x00, 0x00, 0x29, 0x2f, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, ClearChargeTime) {
+  auto frame = AntBms::build_frame_(0x51, 0x23, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x23, 0x00, 0x00, 0x78, 0xef, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, ClearRunningTime) {
+  auto frame = AntBms::build_frame_(0x51, 0x24, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x24, 0x00, 0x00, 0xc9, 0x2e, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, ClearProtectTime) {
+  auto frame = AntBms::build_frame_(0x51, 0x25, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x25, 0x00, 0x00, 0x98, 0xee, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, ResetHardware) {
+  auto frame = AntBms::build_frame_(0x51, 0x2a, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x2a, 0x00, 0x00, 0xa8, 0xed, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsFrameBuilderTest, SaveCustomerData) {
+  auto frame = AntBms::build_frame_(0x51, 0x2c, 0x0000);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x2c, 0x00, 0x00, 0x48, 0xec, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
 }  // namespace esphome::ant_bms::testing

--- a/tests/components/ant_bms/ant_bms_test.cpp
+++ b/tests/components/ant_bms/ant_bms_test.cpp
@@ -290,97 +290,97 @@ TEST(AntBmsDeviceInfoTest, ShortDeviceInfoFrameIgnored) {
 // -- Frame builder ------------------------------------------------------------
 
 TEST(AntBmsFrameBuilderTest, CurrentZero) {
-  auto frame = AntBms::build_frame_(0x51, 0x08, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x08, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x08, 0x00, 0x00, 0x08, 0xe7, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, Restart) {
-  auto frame = AntBms::build_frame_(0x51, 0x09, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x09, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x09, 0x00, 0x00, 0x59, 0x27, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, Shutdown) {
-  auto frame = AntBms::build_frame_(0x51, 0x0b, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x0b, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0b, 0x00, 0x00, 0xf8, 0xe7, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, FactoryReset) {
-  auto frame = AntBms::build_frame_(0x51, 0x0c, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x0c, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0c, 0x00, 0x00, 0x49, 0x26, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, ClearSystemLog) {
-  auto frame = AntBms::build_frame_(0x51, 0x0f, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x0f, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0f, 0x00, 0x00, 0xb9, 0x26, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, BluetoothInitialization) {
-  auto frame = AntBms::build_frame_(0x51, 0x10, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x10, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x10, 0x00, 0x00, 0x88, 0xe0, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, BluetoothOff) {
-  auto frame = AntBms::build_frame_(0x51, 0x1c, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x1c, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x1c, 0x00, 0x00, 0x48, 0xe3, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, BluetoothOn) {
-  auto frame = AntBms::build_frame_(0x51, 0x1d, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x1d, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x1d, 0x00, 0x00, 0x19, 0x23, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, ClearDischargeCycleAh) {
-  auto frame = AntBms::build_frame_(0x51, 0x20, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x20, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x20, 0x00, 0x00, 0x88, 0xef, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, ClearChargeCycleAh) {
-  auto frame = AntBms::build_frame_(0x51, 0x21, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x21, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x21, 0x00, 0x00, 0xd9, 0x2f, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, ClearDischargeTime) {
-  auto frame = AntBms::build_frame_(0x51, 0x22, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x22, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x22, 0x00, 0x00, 0x29, 0x2f, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, ClearChargeTime) {
-  auto frame = AntBms::build_frame_(0x51, 0x23, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x23, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x23, 0x00, 0x00, 0x78, 0xef, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, ClearRunningTime) {
-  auto frame = AntBms::build_frame_(0x51, 0x24, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x24, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x24, 0x00, 0x00, 0xc9, 0x2e, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, ClearProtectTime) {
-  auto frame = AntBms::build_frame_(0x51, 0x25, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x25, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x25, 0x00, 0x00, 0x98, 0xee, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, ResetHardware) {
-  auto frame = AntBms::build_frame_(0x51, 0x2a, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x2a, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x2a, 0x00, 0x00, 0xa8, 0xed, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsFrameBuilderTest, SaveCustomerData) {
-  auto frame = AntBms::build_frame_(0x51, 0x2c, 0x0000);
+  auto frame = AntBms::build_frame(0x51, 0x2c, 0x0000);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x2c, 0x00, 0x00, 0x48, 0xec, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }

--- a/tests/components/ant_bms_ble/ant_bms_ble_test.cpp
+++ b/tests/components/ant_bms_ble/ant_bms_ble_test.cpp
@@ -269,97 +269,97 @@ TEST(AntBmsBleStatusDataTest, NullSensorsDoNotCrash) {
 // -- Frame builder ------------------------------------------------------------
 
 TEST(AntBmsBleFrameBuilderTest, CurrentZero) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0008, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0008, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x08, 0x00, 0x00, 0x08, 0xe7, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, Restart) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0009, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0009, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x09, 0x00, 0x00, 0x59, 0x27, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, Shutdown) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x000b, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x000b, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0b, 0x00, 0x00, 0xf8, 0xe7, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, BluetoothOff) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x001c, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x001c, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x1c, 0x00, 0x00, 0x48, 0xe3, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, BluetoothOn) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x001d, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x001d, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x1d, 0x00, 0x00, 0x19, 0x23, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, ResetHardware) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x002a, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x002a, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x2a, 0x00, 0x00, 0xa8, 0xed, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, SaveCustomerData) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x002c, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x002c, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x2c, 0x00, 0x00, 0x48, 0xec, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, FactoryReset) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x000c, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x000c, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0c, 0x00, 0x00, 0x49, 0x26, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, ClearSystemLog) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x000f, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x000f, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0f, 0x00, 0x00, 0xb9, 0x26, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, BluetoothInitialization) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0010, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0010, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x10, 0x00, 0x00, 0x88, 0xe0, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, ClearDischargeCycleAh) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0020, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0020, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x20, 0x00, 0x00, 0x88, 0xef, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, ClearChargeCycleAh) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0021, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0021, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x21, 0x00, 0x00, 0xd9, 0x2f, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, ClearDischargeTime) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0022, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0022, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x22, 0x00, 0x00, 0x29, 0x2f, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, ClearChargeTime) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0023, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0023, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x23, 0x00, 0x00, 0x78, 0xef, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, ClearRunningTime) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0024, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0024, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x24, 0x00, 0x00, 0xc9, 0x2e, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }
 
 TEST(AntBmsBleFrameBuilderTest, ClearProtectTime) {
-  auto frame = AntBmsBle::build_frame_(0x51, 0x0025, 0x00);
+  auto frame = AntBmsBle::build_frame(0x51, 0x0025, 0x00);
   std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x25, 0x00, 0x00, 0x98, 0xee, 0xaa, 0x55};
   EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
 }

--- a/tests/components/ant_bms_ble/ant_bms_ble_test.cpp
+++ b/tests/components/ant_bms_ble/ant_bms_ble_test.cpp
@@ -266,4 +266,102 @@ TEST(AntBmsBleStatusDataTest, NullSensorsDoNotCrash) {
   bms.assemble(DEVICE_INFO_FRAME.data(), DEVICE_INFO_FRAME.size());
 }
 
+// -- Frame builder ------------------------------------------------------------
+
+TEST(AntBmsBleFrameBuilderTest, CurrentZero) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0008, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x08, 0x00, 0x00, 0x08, 0xe7, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, Restart) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0009, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x09, 0x00, 0x00, 0x59, 0x27, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, Shutdown) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x000b, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0b, 0x00, 0x00, 0xf8, 0xe7, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, BluetoothOff) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x001c, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x1c, 0x00, 0x00, 0x48, 0xe3, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, BluetoothOn) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x001d, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x1d, 0x00, 0x00, 0x19, 0x23, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, ResetHardware) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x002a, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x2a, 0x00, 0x00, 0xa8, 0xed, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, SaveCustomerData) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x002c, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x2c, 0x00, 0x00, 0x48, 0xec, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, FactoryReset) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x000c, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0c, 0x00, 0x00, 0x49, 0x26, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, ClearSystemLog) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x000f, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x0f, 0x00, 0x00, 0xb9, 0x26, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, BluetoothInitialization) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0010, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x10, 0x00, 0x00, 0x88, 0xe0, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, ClearDischargeCycleAh) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0020, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x20, 0x00, 0x00, 0x88, 0xef, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, ClearChargeCycleAh) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0021, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x21, 0x00, 0x00, 0xd9, 0x2f, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, ClearDischargeTime) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0022, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x22, 0x00, 0x00, 0x29, 0x2f, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, ClearChargeTime) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0023, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x23, 0x00, 0x00, 0x78, 0xef, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, ClearRunningTime) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0024, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x24, 0x00, 0x00, 0xc9, 0x2e, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
+TEST(AntBmsBleFrameBuilderTest, ClearProtectTime) {
+  auto frame = AntBmsBle::build_frame_(0x51, 0x0025, 0x00);
+  std::vector<uint8_t> expected = {0x7e, 0xa1, 0x51, 0x25, 0x00, 0x00, 0x98, 0xee, 0xaa, 0x55};
+  EXPECT_EQ(std::vector<uint8_t>(frame.begin(), frame.end()), expected);
+}
+
 }  // namespace esphome::ant_bms_ble::testing

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -98,3 +98,97 @@ sensor:
     ant_bms_old_ble_id: bms3
     total_voltage:
       name: "ant_bms_old_ble total voltage"
+
+switch:
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms0
+    charging:
+      name: "ant_bms_ble charging"
+    discharging:
+      name: "ant_bms_ble discharging"
+    balancer:
+      name: "ant_bms_ble balancer"
+    buzzer:
+      name: "ant_bms_ble buzzer"
+
+  - platform: ant_bms
+    ant_bms_id: bms1
+    charging:
+      name: "ant_bms charging"
+    discharging:
+      name: "ant_bms discharging"
+    balancer:
+      name: "ant_bms balancer"
+    buzzer:
+      name: "ant_bms buzzer"
+
+button:
+  - platform: ant_bms_ble
+    ant_bms_ble_id: bms0
+    current_zero:
+      name: "ant_bms_ble current zero"
+    shutdown:
+      name: "ant_bms_ble shutdown"
+    clear_system_log:
+      name: "ant_bms_ble clear system log"
+    factory_reset:
+      name: "ant_bms_ble factory reset"
+    restart:
+      name: "ant_bms_ble restart"
+    bluetooth_initialization:
+      name: "ant_bms_ble bluetooth initialization"
+    bluetooth_off:
+      name: "ant_bms_ble bluetooth off"
+    bluetooth_on:
+      name: "ant_bms_ble bluetooth on"
+    clear_discharge_cycle_ah:
+      name: "ant_bms_ble clear discharge cycle ah"
+    clear_charge_cycle_ah:
+      name: "ant_bms_ble clear charge cycle ah"
+    clear_discharge_time:
+      name: "ant_bms_ble clear discharge time"
+    clear_charge_time:
+      name: "ant_bms_ble clear charge time"
+    clear_running_time:
+      name: "ant_bms_ble clear running time"
+    clear_protect_time:
+      name: "ant_bms_ble clear protect time"
+    reset_hardware:
+      name: "ant_bms_ble reset hardware"
+    save_customer_data:
+      name: "ant_bms_ble save customer data"
+
+  - platform: ant_bms
+    ant_bms_id: bms1
+    current_zero:
+      name: "ant_bms current zero"
+    shutdown:
+      name: "ant_bms shutdown"
+    clear_system_log:
+      name: "ant_bms clear system log"
+    factory_reset:
+      name: "ant_bms factory reset"
+    restart:
+      name: "ant_bms restart"
+    bluetooth_initialization:
+      name: "ant_bms bluetooth initialization"
+    bluetooth_off:
+      name: "ant_bms bluetooth off"
+    bluetooth_on:
+      name: "ant_bms bluetooth on"
+    clear_discharge_cycle_ah:
+      name: "ant_bms clear discharge cycle ah"
+    clear_charge_cycle_ah:
+      name: "ant_bms clear charge cycle ah"
+    clear_discharge_time:
+      name: "ant_bms clear discharge time"
+    clear_charge_time:
+      name: "ant_bms clear charge time"
+    clear_running_time:
+      name: "ant_bms clear running time"
+    clear_protect_time:
+      name: "ant_bms clear protect time"
+    reset_hardware:
+      name: "ant_bms reset hardware"
+    save_customer_data:
+      name: "ant_bms save customer data"

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -118,13 +118,13 @@ class TestSwitchConstants:
         assert switch.CONF_DISCHARGING in switch.SWITCHES
         assert switch.CONF_CHARGING in switch.SWITCHES
         assert switch.CONF_BALANCER in switch.SWITCHES
-        assert len(switch.SWITCHES) == 5
+        assert len(switch.SWITCHES) == 4
 
     def test_ble_switches_dict(self):
         assert ble_switch.CONF_DISCHARGING in ble_switch.SWITCHES
         assert ble_switch.CONF_CHARGING in ble_switch.SWITCHES
         assert ble_switch.CONF_BALANCER in ble_switch.SWITCHES
-        assert len(ble_switch.SWITCHES) == 5
+        assert len(ble_switch.SWITCHES) == 4
 
 
 class TestButtonConstants:
@@ -135,7 +135,13 @@ class TestButtonConstants:
         assert CONF_RESTART in button.BUTTONS
         assert CONF_FACTORY_RESET in button.BUTTONS
         assert button.CONF_CLEAR_SYSTEM_LOG in button.BUTTONS
-        assert len(button.BUTTONS) == 4
+        assert button.CONF_CURRENT_ZERO in button.BUTTONS
+        assert button.CONF_RESET_HARDWARE in button.BUTTONS
+        assert button.CONF_BLUETOOTH_INITIALIZATION in button.BUTTONS
+        assert button.CONF_SAVE_CUSTOMER_DATA in button.BUTTONS
+        assert button.CONF_BLUETOOTH_ON in button.BUTTONS
+        assert button.CONF_BLUETOOTH_OFF in button.BUTTONS
+        assert len(button.BUTTONS) == 16
 
     def test_button_addresses_are_unique(self):
         addresses = list(button.BUTTONS.values())
@@ -147,4 +153,6 @@ class TestButtonConstants:
         assert ble_button.CONF_SHUTDOWN in ble_button.BUTTONS
         assert CONF_RESTART in ble_button.BUTTONS
         assert CONF_FACTORY_RESET in ble_button.BUTTONS
-        assert len(ble_button.BUTTONS) == 4
+        assert ble_button.CONF_BLUETOOTH_ON in ble_button.BUTTONS
+        assert ble_button.CONF_BLUETOOTH_OFF in ble_button.BUTTONS
+        assert len(ble_button.BUTTONS) == 16


### PR DESCRIPTION
Closes #29

## Summary

- Adds 12 new button entities to both `ant_bms` and `ant_bms_ble` based on the command payloads captured in issue #29: `current_zero`, `reset_hardware`, `bluetooth_initialization`, `save_customer_data`, `clear_discharge_cycle_ah`, `clear_charge_cycle_ah`, `clear_discharge_time`, `clear_charge_time`, `clear_running_time`, `clear_protect_time`, `bluetooth_on`, `bluetooth_off`
- Removes the `bluetooth` switch from both components. Since the BMS does not report its bluetooth state, a switch with unknown assumed state is replaced by two explicit one-shot buttons (`bluetooth_on` / `bluetooth_off`)
- Extracts frame building into a public static method (`build_v2021_frame_` / `build_frame_`) that is testable without hardware or UART
- Adds 16 C++ unit tests (ant_bms) and 7 C++ unit tests (ant_bms_ble) that verify the generated byte sequences against the known-good captures from the issue