### PR TITLE
Add min_auth_mode: WPA2 to wifi configuration

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -32,6 +32,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -24,6 +24,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -19,6 +19,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-example-multiple-devices.yaml
+++ b/esp32-example-multiple-devices.yaml
@@ -36,6 +36,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -27,6 +27,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp32-old-ble-example.yaml
+++ b/esp32-old-ble-example.yaml
@@ -26,6 +26,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 
 ota:

--- a/esp32-old-example.yaml
+++ b/esp32-old-example.yaml
@@ -27,6 +27,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -25,6 +25,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/esp8266-old-example.yaml
+++ b/esp8266-old-example.yaml
@@ -25,6 +25,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -21,6 +21,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-fake-bms-v2021.yaml
+++ b/tests/esp8266-fake-bms-v2021.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-fake-bms.yaml
+++ b/tests/esp8266-fake-bms.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-query-data-v2021.yaml
+++ b/tests/esp8266-query-data-v2021.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-query-data.yaml
+++ b/tests/esp8266-query-data.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/esp8266-test-protocols.yaml
+++ b/tests/esp8266-test-protocols.yaml
@@ -13,6 +13,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome


### PR DESCRIPTION
Add `min_auth_mode: WPA2` to all `wifi:` blocks in ESPHome YAML configurations.

This sets the minimum WiFi authentication mode to WPA2 (AES encryption), which:

- Silences the ESPHome deprecation warning that will change defaults in 2026.6.0
- Ensures WPA2 is used instead of WPA (TKIP), which is more secure

Without this setting, ESPHome 2026.6.0 will emit a deprecation warning and future versions may change the default behavior.