### PR TITLE
Fix crash in assemble() on malformed BLE notifications

### DIFF
--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -273,7 +273,7 @@ void AntBmsBle::assemble(const uint8_t *data, uint16_t length) {
   }
 
   // Flush buffer on every preamble
-  if (data[0] == ANT_PKT_START_1 && data[1] == ANT_PKT_START_2) {
+  if (length >= 2 && data[0] == ANT_PKT_START_1 && data[1] == ANT_PKT_START_2) {
     this->frame_buffer_.clear();
   }
 
@@ -295,6 +295,14 @@ void AntBmsBle::assemble(const uint8_t *data, uint16_t length) {
     // It looks like the data_len value of the device info frame is wrong
     if (frame_len != this->frame_buffer_.size() && function != ANT_FRAME_TYPE_DEVICE_INFO) {
       ESP_LOGW(TAG, "Invalid frame length");
+      this->frame_buffer_.clear();
+      return;
+    }
+
+    // Guard against a wrong data_len causing out-of-bounds access into frame_buffer_.
+    if (frame_len > this->frame_buffer_.size()) {
+      ESP_LOGW(TAG, "Computed frame_len (%u) exceeds buffer (%zu), discarding", frame_len,
+               this->frame_buffer_.size());
       this->frame_buffer_.clear();
       return;
     }

--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -262,9 +262,14 @@ void AntBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
 #endif  // USE_ESP32
 
 void AntBmsBle::assemble(const uint8_t *data, uint16_t length) {
+  // ESP-IDF may pass a null value pointer for zero-length GATTC notifications.
+  if (data == nullptr || length == 0)
+    return;
+
   if (this->frame_buffer_.size() > MAX_RESPONSE_SIZE) {
     ESP_LOGW(TAG, "Maximum response size (%zu bytes) exceeded", this->frame_buffer_.size());
     this->frame_buffer_.clear();
+    return;
   }
 
   // Flush buffer on every preamble

--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -301,8 +301,7 @@ void AntBmsBle::assemble(const uint8_t *data, uint16_t length) {
 
     // Guard against a wrong data_len causing out-of-bounds access into frame_buffer_.
     if (frame_len > this->frame_buffer_.size()) {
-      ESP_LOGW(TAG, "Computed frame_len (%u) exceeds buffer (%zu), discarding", frame_len,
-               this->frame_buffer_.size());
+      ESP_LOGW(TAG, "Computed frame_len (%u) exceeds buffer (%zu), discarding", frame_len, this->frame_buffer_.size());
       this->frame_buffer_.clear();
       return;
     }

--- a/tests/components/ant_bms_ble/ant_bms_ble_test.cpp
+++ b/tests/components/ant_bms_ble/ant_bms_ble_test.cpp
@@ -291,6 +291,33 @@ TEST(AntBmsBleDeviceInfoTest, FragmentedFrameEndingOnEmbeddedEndByte) {
   EXPECT_EQ(version.state, "22AAUB00-241008A");
 }
 
+// ── assemble() guard tests (issue #174) ──────────────────────────────────────
+
+TEST(AntBmsBleAssembleGuardTest, ZeroLengthNotificationDoesNotCrash) {
+  TestableAntBmsBle bms;
+  bms.assemble(STATUS_FRAME_16S.data(), 0);
+}
+
+TEST(AntBmsBleAssembleGuardTest, OneBytePreambleFragmentDoesNotCrash) {
+  TestableAntBmsBle bms;
+  // A BLE notification with only the first preamble byte (0x7E, length=1) must
+  // not access data[1] out-of-bounds and must not flush the buffer prematurely,
+  // so the frame can be completed by the subsequent notification.
+  const uint8_t first_byte = STATUS_FRAME_16S[0];
+  bms.assemble(&first_byte, 1);
+  bms.assemble(STATUS_FRAME_16S.data() + 1, STATUS_FRAME_16S.size() - 1);
+}
+
+TEST(AntBmsBleAssembleGuardTest, DeviceInfoFrameWithInflatedDataLenDoesNotCrash) {
+  TestableAntBmsBle bms;
+  // Corrupt raw[5] (data_len) so that frame_len > frame_buffer_.size().
+  // Without the bounds guard this causes an out-of-bounds read in the CRC
+  // extraction (raw[frame_len - 3]).
+  std::vector<uint8_t> frame(DEVICE_INFO_FRAME);
+  frame[5] = 0xFF;  // frame_len = 6 + 255 + 4 = 265, far beyond actual 48 bytes
+  bms.assemble(frame.data(), frame.size());
+}
+
 // ── Null sensors do not crash ─────────────────────────────────────────────────
 
 TEST(AntBmsBleStatusDataTest, NullSensorsDoNotCrash) {


### PR DESCRIPTION
Four bugs in `assemble()` that cause a LoadProhibited crash (EXCVADDR 0x0):

1. **Null/length guard missing**: ESP-IDF delivers `value=nullptr` when a GATTC notify event carries zero bytes, leading to a crash at `data[0]`.
2. **Missing return after MAX_RESPONSE_SIZE clear**: the function kept processing the current chunk even after discarding the oversized buffer.
3. **Preamble check unguarded for 1-byte fragments**: `data[1]` was accessed without a `length >= 2` check; the guard is now placed directly on the preamble `if`-condition so short fragments are still appended to the buffer.
4. **DEVICE_INFO frame OOB in CRC extraction**: DEVICE_INFO frames bypass the `frame_len == buffer size` check, so a wrong `data_len` in `raw[5]` could make `frame_len > frame_buffer_.size()` and cause an out-of-bounds read when extracting the remote CRC; a bounds guard now discards such frames before the CRC lines.

Fix confirmed by reporter.