### PR TITLE
Split long hex dumps into 100-byte chunks to prevent log line truncation

### DIFF
--- a/components/ant_bms/ant_bms.cpp
+++ b/components/ant_bms/ant_bms.cpp
@@ -7,6 +7,14 @@ namespace esphome::ant_bms {
 
 static const char *const TAG = "ant_bms";
 
+static void log_hex_chunked(const char *tag, const uint8_t *data, size_t size) {
+  char buf[format_hex_pretty_size(100)];
+  for (size_t i = 0; i < size; i += 100) {
+    size_t len = std::min<size_t>(100, size - i);
+    ESP_LOGD(tag, "  %s", format_hex_pretty_to(buf, sizeof(buf), data + i, len, '.'));
+  }
+}
+
 static const uint8_t MAX_NO_RESPONSE_COUNT = 5;
 
 static const uint8_t ANT_PKT_START_1 = 0x7E;
@@ -257,10 +265,7 @@ void AntBms::on_ant_bms_data_(const uint8_t &function, const std::vector<uint8_t
     }
     default:
       ESP_LOGW(TAG, "Unhandled response received (function 0x%02X):", function);
-      for (size_t i = 0; i < data.size(); i += 100) {
-        size_t len = std::min<size_t>(100, data.size() - i);
-        ESP_LOGW(TAG, "  %s", format_hex_pretty(data.data() + i, len).c_str());  // NOLINT
-      }
+      log_hex_chunked(TAG, data.data(), data.size());
   }
 }
 
@@ -273,10 +278,7 @@ void AntBms::on_status_data_(const std::vector<uint8_t> &data) {
   };
 
   ESP_LOGI(TAG, "Status frame (%zu bytes):", data.size());
-  for (size_t i = 0; i < data.size(); i += 100) {
-    size_t len = std::min<size_t>(100, data.size() - i);
-    ESP_LOGD(TAG, "  %s", format_hex_pretty(data.data() + i, len).c_str());  // NOLINT
-  }
+  log_hex_chunked(TAG, data.data(), data.size());
 
   if (data.size() < 6 || data.size() != (6 + data[5] + 4)) {
     ESP_LOGW(TAG, "Skipping status frame because of invalid length");
@@ -447,10 +449,7 @@ void AntBms::on_status_data_(const std::vector<uint8_t> &data) {
 
 void AntBms::on_device_info_data_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "Device info frame (%zu bytes):", data.size());
-  for (size_t i = 0; i < data.size(); i += 100) {
-    size_t len = std::min<size_t>(100, data.size() - i);
-    ESP_LOGD(TAG, "  %s", format_hex_pretty(data.data() + i, len).c_str());  // NOLINT
-  }
+  log_hex_chunked(TAG, data.data(), data.size());
 
   if (data.size() < 38) {
     ESP_LOGW(TAG, "Skipping device info frame because of invalid length");

--- a/components/ant_bms/ant_bms.cpp
+++ b/components/ant_bms/ant_bms.cpp
@@ -218,7 +218,10 @@ bool AntBms::parse_ant_bms_byte_(uint8_t byte) {
     return false;
   }
 
-  ESP_LOGVV(TAG, "RX <- %s", format_hex_pretty(raw, at + 1).c_str());  // NOLINT
+  for (size_t i = 0; i <= (size_t) at; i += 100) {
+    size_t len = std::min<size_t>(100, at + 1 - i);
+    ESP_LOGVV(TAG, "RX <- %s", format_hex_pretty(raw + i, len).c_str());  // NOLINT
+  }
 
   std::vector<uint8_t> data(this->rx_buffer_.begin(), this->rx_buffer_.begin() + frame_len);
 
@@ -253,8 +256,11 @@ void AntBms::on_ant_bms_data_(const uint8_t &function, const std::vector<uint8_t
       break;
     }
     default:
-      ESP_LOGW(TAG, "Unhandled response received (function 0x%02X): %s", function,
-               format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
+      ESP_LOGW(TAG, "Unhandled response received (function 0x%02X):", function);
+      for (size_t i = 0; i < data.size(); i += 100) {
+        size_t len = std::min<size_t>(100, data.size() - i);
+        ESP_LOGW(TAG, "  %s", format_hex_pretty(data.data() + i, len).c_str());  // NOLINT
+      }
   }
 }
 
@@ -267,7 +273,10 @@ void AntBms::on_status_data_(const std::vector<uint8_t> &data) {
   };
 
   ESP_LOGI(TAG, "Status frame (%zu bytes):", data.size());
-  ESP_LOGD(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
+  for (size_t i = 0; i < data.size(); i += 100) {
+    size_t len = std::min<size_t>(100, data.size() - i);
+    ESP_LOGD(TAG, "  %s", format_hex_pretty(data.data() + i, len).c_str());  // NOLINT
+  }
 
   if (data.size() < 6 || data.size() != (6 + data[5] + 4)) {
     ESP_LOGW(TAG, "Skipping status frame because of invalid length");
@@ -438,7 +447,10 @@ void AntBms::on_status_data_(const std::vector<uint8_t> &data) {
 
 void AntBms::on_device_info_data_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "Device info frame (%zu bytes):", data.size());
-  ESP_LOGD(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
+  for (size_t i = 0; i < data.size(); i += 100) {
+    size_t len = std::min<size_t>(100, data.size() - i);
+    ESP_LOGD(TAG, "  %s", format_hex_pretty(data.data() + i, len).c_str());  // NOLINT
+  }
 
   if (data.size() < 38) {
     ESP_LOGW(TAG, "Skipping device info frame because of invalid length");

--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -14,6 +14,14 @@ namespace esphome::ant_bms_ble {
 
 static const char *const TAG = "ant_bms_ble";
 
+static void log_hex_chunked(const char *tag, const uint8_t *data, size_t size) {
+  char buf[format_hex_pretty_size(100)];
+  for (size_t i = 0; i < size; i += 100) {
+    size_t len = std::min<size_t>(100, size - i);
+    ESP_LOGD(tag, "  %s", format_hex_pretty_to(buf, sizeof(buf), data + i, len, '.'));
+  }
+}
+
 static const uint8_t MAX_NO_RESPONSE_COUNT = 10;
 
 static const uint16_t ANT_BMS_SERVICE_UUID = 0xFFE0;
@@ -370,10 +378,7 @@ void AntBmsBle::on_status_data_(const std::vector<uint8_t> &data) {
   };
 
   ESP_LOGI(TAG, "Status frame (%zu bytes):", data.size());
-  for (size_t i = 0; i < data.size(); i += 100) {
-    size_t len = std::min<size_t>(100, data.size() - i);
-    ESP_LOGD(TAG, "  %s", format_hex_pretty(data.data() + i, len).c_str());  // NOLINT
-  }
+  log_hex_chunked(TAG, data.data(), data.size());
 
   if (data.size() != (6 + data[5] + 4)) {
     ESP_LOGW(TAG, "Skipping status frame because of invalid length");

--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -370,7 +370,10 @@ void AntBmsBle::on_status_data_(const std::vector<uint8_t> &data) {
   };
 
   ESP_LOGI(TAG, "Status frame (%zu bytes):", data.size());
-  ESP_LOGD(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
+  for (size_t i = 0; i < data.size(); i += 100) {
+    size_t len = std::min<size_t>(100, data.size() - i);
+    ESP_LOGD(TAG, "  %s", format_hex_pretty(data.data() + i, len).c_str());  // NOLINT
+  }
 
   if (data.size() != (6 + data[5] + 4)) {
     ESP_LOGW(TAG, "Skipping status frame because of invalid length");


### PR DESCRIPTION
## Summary

- Status frames (178+ bytes) were silently truncated in the ESP log output because the entire hex dump was emitted as a single log line
- All `format_hex_pretty` hex dumps in `ant_bms` and `ant_bms_ble` are now split into 100-byte chunks, each on its own log line
- Affected locations: status frame, device info frame, raw RX buffer (LOGVV), and unhandled response warning