### PR TITLE
Improve frame recovery after buffer overflow in assemble()

### DIFF
--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -277,7 +277,6 @@ void AntBmsBle::assemble(const uint8_t *data, uint16_t length) {
   if (this->frame_buffer_.size() > MAX_RESPONSE_SIZE) {
     ESP_LOGW(TAG, "Maximum response size (%zu bytes) exceeded", this->frame_buffer_.size());
     this->frame_buffer_.clear();
-    return;
   }
 
   // Flush buffer on every preamble


### PR DESCRIPTION
## Summary

- Removes the early `return` after clearing an oversized `frame_buffer_`
- After the clear, the incoming notification chunk is now processed normally by the existing preamble-flush logic
- If the chunk starts with the frame preamble (`ANT_PKT_START_1 ANT_PKT_START_2`), it becomes the first chunk of the next valid frame — recovery is immediate
- If the chunk is mid-frame data, it is appended to the now-empty buffer and discarded later by the existing parse checks — no regression

## Background

#175 introduced the overflow guard to fix a crash. The `return` was conservative but slightly too aggressive: it discards a notification that could already be the start of the next valid frame, delaying recovery by one full BLE notification cycle.

## Test plan

- [ ] Verify normal frame parsing still works (no regression)
- [ ] Trigger a buffer overflow condition and confirm the next frame-start notification is picked up immediately rather than dropped