### PR TITLE
Add throttle option to suppress redundant status frame updates

### DIFF
--- a/components/ant_bms_ble/__init__.py
+++ b/components/ant_bms_ble/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import ble_client
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_THROTTLE
 
 CODEOWNERS = ["@syssi"]
 
@@ -26,6 +26,9 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(AntBmsBle),
+            cv.Optional(
+                CONF_THROTTLE, default="0s"
+            ): cv.positive_time_period_milliseconds,
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
@@ -37,3 +40,5 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await ble_client.register_ble_node(var, config)
+
+    cg.add(var.set_throttle(config[CONF_THROTTLE]))

--- a/components/ant_bms_ble/ant_bms_ble.cpp
+++ b/components/ant_bms_ble/ant_bms_ble.cpp
@@ -395,6 +395,12 @@ void AntBmsBle::on_ant_bms_ble_data_(const uint8_t &function, const std::vector<
 }
 
 void AntBmsBle::on_status_data_(const std::vector<uint8_t> &data) {
+  const uint32_t now = millis();
+  if (this->throttle_ > 0 && now - this->last_status_data_ < this->throttle_) {
+    return;
+  }
+  this->last_status_data_ = now;
+
   auto ant_get_16bit = [&](size_t i) -> uint16_t {
     return (uint16_t(data[i + 1]) << 8) | (uint16_t(data[i + 0]) << 0);
   };

--- a/components/ant_bms_ble/ant_bms_ble.h
+++ b/components/ant_bms_ble/ant_bms_ble.h
@@ -143,6 +143,7 @@ class AntBmsBle :
   void set_buzzer_switch(switch_::Switch *buzzer_switch) { buzzer_switch_ = buzzer_switch; }
 
   void set_password(const std::string &password) { this->password_ = password; }
+  void set_throttle(uint32_t throttle) { this->throttle_ = throttle; }
 
   void assemble(const uint8_t *data, uint16_t length);
   static std::array<uint8_t, 10> build_frame(uint8_t function, uint16_t address, uint8_t value);
@@ -206,6 +207,8 @@ class AntBmsBle :
   std::vector<uint8_t> frame_buffer_;
   uint8_t no_response_count_{0};
   uint16_t characteristic_handle_{0};
+  uint32_t last_status_data_{0};
+  uint32_t throttle_{0};
 
   void on_ant_bms_ble_data_(const uint8_t &function, const std::vector<uint8_t> &data);
   void on_status_data_(const std::vector<uint8_t> &data);

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -67,10 +67,12 @@ ant_bms_ble:
   - id: bms0
     ble_client_id: client0
     update_interval: 5s
-    # throttle: 5s  # Drop status frames arriving faster than every 5 s (useful for models that send a continuous stream of notifications)
+    # Recommended for models that send a continuous stream of notifications instead of a single response per request.
+    # throttle: 5s
   - id: bms1
     ble_client_id: client1
     update_interval: 5s
+    # Recommended for models that send a continuous stream of notifications instead of a single response per request.
     # throttle: 5s
 
 binary_sensor:

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -67,9 +67,11 @@ ant_bms_ble:
   - id: bms0
     ble_client_id: client0
     update_interval: 5s
+    # throttle: 5s  # Drop status frames arriving faster than every 5 s (useful for models that send a continuous stream of notifications)
   - id: bms1
     ble_client_id: client1
     update_interval: 5s
+    # throttle: 5s
 
 binary_sensor:
   - platform: ant_bms_ble

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -57,7 +57,8 @@ ant_bms_ble:
   - id: bms0
     ble_client_id: client0
     update_interval: 5s
-    # throttle: 5s  # Drop status frames arriving faster than every 5 s (useful for models that send a continuous stream of notifications)
+    # Recommended for models that send a continuous stream of notifications instead of a single response per request.
+    # throttle: 5s
 
 binary_sensor:
   - platform: ant_bms_ble

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -57,6 +57,7 @@ ant_bms_ble:
   - id: bms0
     ble_client_id: client0
     update_interval: 5s
+    # throttle: 5s  # Drop status frames arriving faster than every 5 s (useful for models that send a continuous stream of notifications)
 
 binary_sensor:
   - platform: ant_bms_ble

--- a/tests/components/ant_bms_ble/test.host.yaml
+++ b/tests/components/ant_bms_ble/test.host.yaml
@@ -1,3 +1,4 @@
 ant_bms_ble:
   id: test_bms
   update_interval: 20s
+  throttle: 5s

--- a/tests/components/ant_bms_ble/test.host.yaml
+++ b/tests/components/ant_bms_ble/test.host.yaml
@@ -1,4 +1,5 @@
 ant_bms_ble:
   id: test_bms
   update_interval: 20s
-  throttle: 5s
+  # Recommended for models that send a continuous stream of notifications instead of a single response per request.
+  # throttle: 5s

--- a/tests/components/ant_bms_ble/test.host.yaml
+++ b/tests/components/ant_bms_ble/test.host.yaml
@@ -1,5 +1,3 @@
 ant_bms_ble:
   id: test_bms
   update_interval: 20s
-  # Recommended for models that send a continuous stream of notifications instead of a single response per request.
-  # throttle: 5s

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -47,6 +47,7 @@ ant_bms_ble:
   - id: bms0
     ble_client_id: client0
     update_interval: 5s
+    throttle: 5s
 
 ant_bms_old_ble:
   - id: bms3

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -47,7 +47,8 @@ ant_bms_ble:
   - id: bms0
     ble_client_id: client0
     update_interval: 5s
-    throttle: 5s
+    # Recommended for models that send a continuous stream of notifications instead of a single response per request.
+    # throttle: 5s
 
 ant_bms_old_ble:
   - id: bms3


### PR DESCRIPTION
## Summary

- Adds optional `throttle` parameter (default `0s`, disabled) to the `ant_bms_ble` component configuration
- Status frames arriving within the throttle interval are silently discarded in `on_status_data_`
- Polling behaviour and request frequency are unchanged — only the processing of incoming notifications is gated
- Follows the same pattern used in `esphome-jk-bms/components/jk_bms_ble`

**Example usage:**
```yaml
ant_bms_ble:
  - id: bms
    ble_client_id: bms_client
    throttle: 5s   # discard status frames arriving faster than every 5 s
```

## Test plan

- [ ] Compile with no `throttle` key → default `0s` → guard condition (`throttle_ > 0`) is false, all frames processed as before
- [ ] Compile with `throttle: 5s` → only the first frame in each 5 s window triggers sensor updates
- [ ] Verify polling interval and BLE request count are not affected